### PR TITLE
CONTOSO: Add manual trigger for CI checks

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -3,10 +3,7 @@ name: "CodeQL"
 on:
   push:
     branches: [ "main" ]
-  pull_request:
-    branches: [ "main" ]
-  schedule:
-    - cron: '00 10 * * 5'
+  workflow_dispatch:
 
 env:
   DOTNET_VERSION: 9.0.x

--- a/.github/workflows/pr-checks-monolith.yml
+++ b/.github/workflows/pr-checks-monolith.yml
@@ -10,6 +10,7 @@ on:
       - "database/**"
       - ".github/codeql.yml"
       - ".github/pr-checks-monolith.yml"
+  workflow_dispatch:
 
 env:
   DOTNET_VERSION: 9.0.x

--- a/.github/workflows/pr-checks-monolith.yml
+++ b/.github/workflows/pr-checks-monolith.yml
@@ -8,7 +8,8 @@ on:
     paths: 
       - "apps/monolith/**"
       - "database/**"
-      - ".github/**"
+      - ".github/codeql.yml"
+      - ".github/pr-checks-monolith.yml"
 
 env:
   DOTNET_VERSION: 9.0.x

--- a/.github/workflows/pr-checks-mservices.yml
+++ b/.github/workflows/pr-checks-mservices.yml
@@ -8,7 +8,8 @@ on:
     paths: 
       - "apps/mservices/**"
       - "database/**"
-      - ".github/**"
+      - ".github/codeql.yml"
+      - ".github/pr-checks-mservices.yml"
 
 env:
   DOTNET_VERSION: 9.0.x

--- a/.github/workflows/pr-checks-mservices.yml
+++ b/.github/workflows/pr-checks-mservices.yml
@@ -10,6 +10,7 @@ on:
       - "database/**"
       - ".github/codeql.yml"
       - ".github/pr-checks-mservices.yml"
+  workflow_dispatch:
 
 env:
   DOTNET_VERSION: 9.0.x


### PR DESCRIPTION
Key point:
- CodeQL should be required but a manual step
- The same for "other" WFs not triggered by `[ push | pull_request ]` event

References:
- google: _github required checks monorepo_
- https://github.com/orgs/community/discussions/26251
- https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/collaborating-on-repositories-with-code-quality-features/troubleshooting-required-status-checks#handling-skipped-but-required-checks
- https://dev.to/tmrc/scoped-github-status-checks-in-a-monorepo-1ni5
- https://engineering.mixpanel.com/enforcing-required-checks-on-conditional-ci-jobs-in-a-github-monorepo-8d4949694340
- https://forum.buildkite.community/t/monorepo-github-require-status-checks/3332
- https://community.sonarsource.com/t/monorepos-and-github-status-checks/73478
- https://brunoscheufler.com/blog/2022-04-24-required-github-actions-jobs-in-a-monorepo
- https://github.com/tinyfists/actions-monorepo
- https://discuss.circleci.com/t/monorepo-problems-with-github-checks/51509
- https://discuss.circleci.com/t/dynamic-configuration-vs-github-required-checks/41754/12
- https://github.com/orgs/community/discussions/26857