### PR TITLE
CONTOSO: Enable `TreatWarningsAsErrors`

### DIFF
--- a/apps/monolith/Directory.Build.props
+++ b/apps/monolith/Directory.Build.props
@@ -4,4 +4,9 @@
         <TargetFramework>net10.0</TargetFramework>
     </PropertyGroup>
 
+    <PropertyGroup>
+        <NoWarn>NU1902;CS0618</NoWarn>
+        <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    </PropertyGroup>
+
 </Project>

--- a/apps/mservices/Directory.Build.props
+++ b/apps/mservices/Directory.Build.props
@@ -4,4 +4,9 @@
         <TargetFramework>net10.0</TargetFramework>
     </PropertyGroup>
 
+    <PropertyGroup>
+        <NoWarn>NU1902;NU1608;CS0618</NoWarn>
+        <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    </PropertyGroup>
+
 </Project>


### PR DESCRIPTION
This pull request adds stricter build settings to both the `apps/monolith` and `apps/mservices` projects to improve code quality and maintainability. The main changes involve treating all warnings as errors and specifying which warnings to suppress.

**Build configuration improvements:**

* Both `apps/monolith/Directory.Build.props` and `apps/mservices/Directory.Build.props` now set `<TreatWarningsAsErrors>true</TreatWarningsAsErrors>` to ensure that all compiler warnings will break the build, enforcing higher code quality. [[1]](diffhunk://#diff-8a9635e6bb64642191ee8241441c40fac871fdf81910459ef8ab13a124d6838cR7-R11) [[2]](diffhunk://#diff-620c983cc8bb2cbb66d8fff95768e7a22d7c7e27cc80fa1c936f2651618bb724R7-R11)
* Specific warnings are suppressed using the `<NoWarn>` property:
  * `apps/monolith` suppresses `NU1902` (package version compatibility) and `CS0618` (usage of obsolete members).
  * `apps/mservices` suppresses `NU1902`, `NU1608` (dependency version conflicts), and `CS0618`.
* These suppressions will be addressed with focused issues to be resolved