### PR TITLE
CONTOSO: Fix `CS0618` warning suppression (#221)

### DIFF
--- a/apps/monolith/Directory.Build.props
+++ b/apps/monolith/Directory.Build.props
@@ -5,7 +5,7 @@
     </PropertyGroup>
 
     <PropertyGroup>
-        <NoWarn>NU1902;CS0618</NoWarn>
+        <NoWarn>NU1902</NoWarn>
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     </PropertyGroup>
 

--- a/apps/monolith/test/integration/ContosoUniversity.Mvc.IntegrationTests/InfrastructureContext.cs
+++ b/apps/monolith/test/integration/ContosoUniversity.Mvc.IntegrationTests/InfrastructureContext.cs
@@ -23,8 +23,7 @@ public class InfrastructureContext : IAsyncLifetime
                 Directory.GetCurrentDirectory(),
                 relativePath));
 
-    private readonly MsSqlContainer _msSqlContainer = new MsSqlBuilder()
-        .WithImage("mcr.microsoft.com/mssql/server")
+    private readonly MsSqlContainer _msSqlContainer = new MsSqlBuilder("mcr.microsoft.com/mssql/server")
         .WithBindMount(GetFullPathTo(DatabaseDirectory), "/scripts", AccessMode.ReadOnly)
         .WithWorkingDirectory("/scripts")
         // .WithPortBinding(1477, 1433)

--- a/apps/mservices/Directory.Build.props
+++ b/apps/mservices/Directory.Build.props
@@ -5,7 +5,7 @@
     </PropertyGroup>
 
     <PropertyGroup>
-        <NoWarn>NU1902;NU1608;CS0618</NoWarn>
+        <NoWarn>NU1902;NU1608</NoWarn>
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     </PropertyGroup>
 

--- a/apps/mservices/test/integration/IntegrationTesting.SharedKernel/MsSqlContext.cs
+++ b/apps/mservices/test/integration/IntegrationTesting.SharedKernel/MsSqlContext.cs
@@ -19,8 +19,7 @@ public class MsSqlContext : IAsyncLifetime
                 Directory.GetCurrentDirectory(),
                 relativePath));
 
-    private readonly MsSqlContainer _msSqlContainer = new MsSqlBuilder()
-        .WithImage("mcr.microsoft.com/mssql/server")
+    private readonly MsSqlContainer _msSqlContainer = new MsSqlBuilder("mcr.microsoft.com/mssql/server")
         .WithBindMount(GetFullPathTo(DatabaseDirectory), "/scripts", AccessMode.ReadOnly)
         .WithWorkingDirectory("/scripts")
         // .WithPortBinding(1477, 1433)

--- a/apps/mservices/test/integration/IntegrationTesting.SharedKernel/RabbitMqContext.cs
+++ b/apps/mservices/test/integration/IntegrationTesting.SharedKernel/RabbitMqContext.cs
@@ -12,8 +12,7 @@ public class RabbitMqContext : IAsyncLifetime
     private const string RabbitmqConf = "../../../../../../../../rabbitmq.conf";
     private const string DefinitionsJson = "../../../../../../../../definitions.json";
 
-    private readonly RabbitMqContainer _rabbitMqContainer = new RabbitMqBuilder()
-        .WithImage("rabbitmq:management")
+    private readonly RabbitMqContainer _rabbitMqContainer = new RabbitMqBuilder("rabbitmq:management")
         .WithUsername("guest")
         .WithPassword("guest")
         .WithBindMount(RabbitmqConf.ToAbsolutePath(), "/etc/rabbitmq/rabbitmq.conf", AccessMode.ReadOnly)


### PR DESCRIPTION
This pull request introduces several improvements to the integration test infrastructure and project configuration files. The main changes include updating the way container images are specified in test context classes and adjusting compiler warning configurations in project files.

**Integration test infrastructure updates:**

* Updated the initialization of `MsSqlBuilder` in both `InfrastructureContext.cs` and `MsSqlContext.cs` to specify the image name directly in the constructor, simplifying the code and removing the separate `.WithImage()` call. [[1]](diffhunk://#diff-66cb011e89c96ee1f818ca728b908f7f76ea91f7a5497a9bce5af7f727680439L26-R26) [[2]](diffhunk://#diff-5b140c72dea2ca01239b8ab3e32fabb93aacf77a6c9ac36376818c5cfb344437L22-R22)
* Updated the initialization of `RabbitMqBuilder` in `RabbitMqContext.cs` to specify the image name directly in the constructor, removing the separate `.WithImage()` call.

**Project configuration changes:**

* Removed suppression of warning `CS0618` (usage of obsolete members) from the `NoWarn` property in both `apps/monolith/Directory.Build.props` and `apps/mservices/Directory.Build.props`, ensuring that obsolete API usage is now treated as an error. [[1]](diffhunk://#diff-8a9635e6bb64642191ee8241441c40fac871fdf81910459ef8ab13a124d6838cL8-R8) [[2]](diffhunk://#diff-620c983cc8bb2cbb66d8fff95768e7a22d7c7e27cc80fa1c936f2651618bb724L8-R8)