### PR TITLE
CONTOSO: Fix `NU1902` warning suppression (#219)

### DIFF
--- a/apps/monolith/Directory.Build.props
+++ b/apps/monolith/Directory.Build.props
@@ -5,7 +5,6 @@
     </PropertyGroup>
 
     <PropertyGroup>
-        <NoWarn>NU1902</NoWarn>
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     </PropertyGroup>
 

--- a/apps/monolith/Directory.Packages.props
+++ b/apps/monolith/Directory.Packages.props
@@ -6,7 +6,6 @@
     <PackageVersion Include="FluentValidation" Version="12.1.1" />
     <PackageVersion Include="FluentValidation.DependencyInjectionExtensions" Version="12.1.1" />
     <PackageVersion Include="MediatR" Version="14.1.0" />
-    <PackageVersion Include="AspNetCore.HealthChecks.UI" Version="9.0.0" />
     <PackageVersion Include="AspNetCore.HealthChecks.UI.Client" Version="9.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Http" Version="8.0.1" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="10.0.3" />
@@ -34,14 +33,14 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageVersion>
-    <PackageVersion Include="OpenTelemetry.Exporter.Console" Version="1.15.0" />
-    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.0" />
-    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.15.0" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.15.0" />
+    <PackageVersion Include="OpenTelemetry.Exporter.Console" Version="1.15.3" />
+    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3" />
+    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.15.3" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.15.2" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.EntityFrameworkCore" Version="1.15.0-beta.1" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.Process" Version="1.15.0-beta.1" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.15.0" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.SqlClient" Version="1.15.1" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.15.1" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.SqlClient" Version="1.15.2" />
     <PackageVersion Include="Serilog.AspNetCore" Version="10.0.0" />
     <PackageVersion Include="Serilog.Enrichers.ClientInfo" Version="2.9.0" />
     <PackageVersion Include="Serilog.Enrichers.Environment" Version="3.0.1" />

--- a/apps/monolith/src/ContosoUniversity.Mvc/ContosoUniversity.Mvc.csproj
+++ b/apps/monolith/src/ContosoUniversity.Mvc/ContosoUniversity.Mvc.csproj
@@ -5,7 +5,6 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="AspNetCore.HealthChecks.UI" />
         <PackageReference Include="AspNetCore.HealthChecks.UI.Client" />
         <PackageReference Include="FluentValidation" />
         <PackageReference Include="FluentValidation.DependencyInjectionExtensions" />

--- a/apps/mservices/Directory.Build.props
+++ b/apps/mservices/Directory.Build.props
@@ -5,7 +5,7 @@
     </PropertyGroup>
 
     <PropertyGroup>
-        <NoWarn>NU1902;NU1608</NoWarn>
+        <NoWarn>NU1608</NoWarn>
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     </PropertyGroup>
 

--- a/apps/mservices/Directory.Packages.props
+++ b/apps/mservices/Directory.Packages.props
@@ -11,7 +11,6 @@
     <PackageVersion Include="FluentValidation" Version="12.1.1" />
     <PackageVersion Include="FluentValidation.DependencyInjectionExtensions" Version="12.1.1" />
     <PackageVersion Include="MediatR" Version="14.1.0" />
-    <PackageVersion Include="AspNetCore.HealthChecks.UI" Version="9.0.0" />
     <PackageVersion Include="AspNetCore.HealthChecks.UI.Client" Version="9.0.0" />
     <PackageVersion Include="Microsoft.Data.SqlClient" Version="6.1.4" />
     <PackageVersion Include="Microsoft.Extensions.Http" Version="10.0.3" />
@@ -46,7 +45,7 @@
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.3" />
     <PackageVersion Include="Testcontainers.MsSql" Version="4.10.0" />
     <PackageVersion Include="Testcontainers.RabbitMq" Version="4.10.0" />
-    <PackageVersion Include="WireMock.Net" Version="1.25.0" />
+    <PackageVersion Include="WireMock.Net" Version="2.5.0" />
     <PackageVersion Include="xunit" Version="2.9.3" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>

--- a/apps/mservices/src/ContosoUniversity.Mvc/ContosoUniversity.Mvc.csproj
+++ b/apps/mservices/src/ContosoUniversity.Mvc/ContosoUniversity.Mvc.csproj
@@ -5,7 +5,6 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="AspNetCore.HealthChecks.UI" />
         <PackageReference Include="AspNetCore.HealthChecks.UI.Client" />
         <PackageReference Include="FluentValidation" />
         <PackageReference Include="FluentValidation.DependencyInjectionExtensions" />

--- a/apps/mservices/src/Courses.Api/Courses.Api.csproj
+++ b/apps/mservices/src/Courses.Api/Courses.Api.csproj
@@ -7,7 +7,6 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="AspNetCore.HealthChecks.UI" />
         <PackageReference Include="AspNetCore.HealthChecks.UI.Client" />
         <PackageReference Include="MassTransit.RabbitMQ" />
     </ItemGroup>

--- a/apps/mservices/src/Departments.Api/Departments.Api.csproj
+++ b/apps/mservices/src/Departments.Api/Departments.Api.csproj
@@ -7,7 +7,6 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="AspNetCore.HealthChecks.UI" />
         <PackageReference Include="AspNetCore.HealthChecks.UI.Client" />
         <PackageReference Include="MassTransit.RabbitMQ" />
     </ItemGroup>

--- a/apps/mservices/src/Students.Api/Students.Api.csproj
+++ b/apps/mservices/src/Students.Api/Students.Api.csproj
@@ -7,7 +7,6 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="AspNetCore.HealthChecks.UI" />
         <PackageReference Include="AspNetCore.HealthChecks.UI.Client" />
     </ItemGroup>
 

--- a/apps/mservices/test/integration/IntegrationTesting.SharedKernel/IntegrationTesting.SharedKernel.csproj
+++ b/apps/mservices/test/integration/IntegrationTesting.SharedKernel/IntegrationTesting.SharedKernel.csproj
@@ -6,7 +6,6 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="AspNetCore.HealthChecks.UI" />
         <PackageReference Include="AspNetCore.HealthChecks.UI.Client" />
         <PackageReference Include="FluentAssertions" />
         <PackageReference Include="MassTransit.RabbitMQ" />


### PR DESCRIPTION
This pull request primarily removes the `AspNetCore.HealthChecks.UI` package from all projects and updates several package versions to improve consistency and maintainability. It also adjusts warning suppression settings and updates a test dependency.

**Dependency cleanup and updates:**

* Removed all references to the `AspNetCore.HealthChecks.UI` package from project files and central package management, standardizing on using only `AspNetCore.HealthChecks.UI.Client` where needed. [[1]](diffhunk://#diff-118d33c27201ae7755b7988a7f061d3e2af9df0b90547b1d0a7bdf68e6ff72fbL9) [[2]](diffhunk://#diff-9fc3a5b14cd432439d4c958ef6aab163b9188030106f2bc07062e521dc30f417L14) [[3]](diffhunk://#diff-0130747a7615927079e9c31310eee79cdb104fe7ef492ddbf835426725dea209L8) [[4]](diffhunk://#diff-769845c6f2cbb12021b826643c744fdee0f2c9c6b08a30d16a6e649e7d9ba019L8) [[5]](diffhunk://#diff-c1a08ea07cb0f8f410ed3c2c9cfea7cae2738a5506185c38c077e172f4b380d9L10) [[6]](diffhunk://#diff-bd2844e0d7a0c78fe9952d4bcb4652bf839c31260be4f6dec8cfad667b103cc7L10) [[7]](diffhunk://#diff-4577bd6124e1ff58872f55e877e83e5da645cbfa38d86c0cb8c896ff347488baL10) [[8]](diffhunk://#diff-83d83f1a8b7f8a77107d5b81d809721c9018f280c5469c709ae4a468654ef990L9)
* Updated various `OpenTelemetry` packages to more recent patch versions to ensure better compatibility and bug fixes.
* Updated `WireMock.Net` test dependency from version 1.25.0 to 2.5.0.

**Build configuration adjustments:**

* Removed suppression of warning `NU1902` from `apps/monolith/Directory.Build.props` and adjusted `NoWarn` settings in `apps/mservices/Directory.Build.props` to only suppress `NU1608`. [[1]](diffhunk://#diff-8a9635e6bb64642191ee8241441c40fac871fdf81910459ef8ab13a124d6838cL8) [[2]](diffhunk://#diff-620c983cc8bb2cbb66d8fff95768e7a22d7c7e27cc80fa1c936f2651618bb724L8-R8)