### PR TITLE
CONTOSO: Remove `NU1608` warning suppression (#220)

### DIFF
--- a/apps/mservices/Directory.Build.props
+++ b/apps/mservices/Directory.Build.props
@@ -5,7 +5,6 @@
     </PropertyGroup>
 
     <PropertyGroup>
-        <NoWarn>NU1608</NoWarn>
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     </PropertyGroup>
 


### PR DESCRIPTION
Was fixed by #223 