### PR TITLE
CONTOSO: Enable Code Analysis

### DIFF
--- a/apps/monolith/.editorconfig
+++ b/apps/monolith/.editorconfig
@@ -69,7 +69,11 @@ csharp_preserve_single_line_blocks = true
 
 # Language and unnecessary rules
 # https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/language-rules
+dotnet_diagnostic.IDE0001.severity = error # Simplify name
+dotnet_diagnostic.IDE0002.severity = error # Simplify member access
 dotnet_diagnostic.IDE0005.severity = error # Remove unnecessary using directives
 dotnet_diagnostic.IDE0011.severity = error # Add braces
 dotnet_diagnostic.IDE0044.severity = error # Add readonly modifier
+dotnet_diagnostic.IDE0051.severity = error # Remove unused private members
+dotnet_diagnostic.IDE0052.severity = error # Remove unread private member
 dotnet_diagnostic.IDE0290.severity = error # Use primary constructor

--- a/apps/monolith/.editorconfig
+++ b/apps/monolith/.editorconfig
@@ -77,3 +77,8 @@ dotnet_diagnostic.IDE0044.severity = error # Add readonly modifier
 dotnet_diagnostic.IDE0051.severity = error # Remove unused private members
 dotnet_diagnostic.IDE0052.severity = error # Remove unread private member
 dotnet_diagnostic.IDE0290.severity = error # Use primary constructor
+
+# Global suppressions
+
+# AnalysisMode: Default
+dotnet_diagnostic.CS1591.severity = none # Missing XML comment for publicly visible type or member

--- a/apps/monolith/Directory.Build.props
+++ b/apps/monolith/Directory.Build.props
@@ -7,11 +7,10 @@
     <PropertyGroup>
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
         <AnalysisMode>Default</AnalysisMode>
-        <AnalysisLevel>latest</AnalysisLevel>
+        <AnalysisLevel>10.0</AnalysisLevel>
         <CodeAnalysisTreatWarningsAsErrors>true</CodeAnalysisTreatWarningsAsErrors>
         <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
-        <NoWarn>CS1591</NoWarn>
     </PropertyGroup>
 
 </Project>

--- a/apps/monolith/Directory.Build.props
+++ b/apps/monolith/Directory.Build.props
@@ -9,6 +9,9 @@
         <AnalysisMode>Default</AnalysisMode>
         <AnalysisLevel>latest</AnalysisLevel>
         <CodeAnalysisTreatWarningsAsErrors>true</CodeAnalysisTreatWarningsAsErrors>
+        <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
+        <GenerateDocumentationFile>true</GenerateDocumentationFile>
+        <NoWarn>CS1591</NoWarn>
     </PropertyGroup>
 
 </Project>

--- a/apps/monolith/Directory.Build.props
+++ b/apps/monolith/Directory.Build.props
@@ -8,7 +8,6 @@
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
         <AnalysisMode>Default</AnalysisMode>
         <AnalysisLevel>latest</AnalysisLevel>
-        <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
         <CodeAnalysisTreatWarningsAsErrors>true</CodeAnalysisTreatWarningsAsErrors>
     </PropertyGroup>
 

--- a/apps/monolith/Directory.Build.props
+++ b/apps/monolith/Directory.Build.props
@@ -6,6 +6,10 @@
 
     <PropertyGroup>
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+        <AnalysisMode>Default</AnalysisMode>
+        <AnalysisLevel>latest</AnalysisLevel>
+        <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
+        <CodeAnalysisTreatWarningsAsErrors>true</CodeAnalysisTreatWarningsAsErrors>
     </PropertyGroup>
 
 </Project>

--- a/apps/monolith/src/ContosoUniversity.Data.Courses.Writes/ContosoUniversity.Data.Courses.Writes.csproj
+++ b/apps/monolith/src/ContosoUniversity.Data.Courses.Writes/ContosoUniversity.Data.Courses.Writes.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <NoWarn>1701;1702;CS8981</NoWarn>
+        <NoWarn>$(NoWarn);CS8981</NoWarn>
     </PropertyGroup>
 
     <ItemGroup>

--- a/apps/monolith/src/ContosoUniversity.Data.Departments.Writes/ContosoUniversity.Data.Departments.Writes.csproj
+++ b/apps/monolith/src/ContosoUniversity.Data.Departments.Writes/ContosoUniversity.Data.Departments.Writes.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <NoWarn>1701;1702;CS8981</NoWarn>
+        <NoWarn>$(NoWarn);CS8981</NoWarn>
     </PropertyGroup>
 
     <ItemGroup>

--- a/apps/monolith/src/ContosoUniversity.Data.Students.Writes/ContosoUniversity.Data.Students.Writes.csproj
+++ b/apps/monolith/src/ContosoUniversity.Data.Students.Writes/ContosoUniversity.Data.Students.Writes.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <NoWarn>1701;1702;CS8981</NoWarn>
+        <NoWarn>$(NoWarn);CS8981</NoWarn>
     </PropertyGroup>
 
     <ItemGroup>

--- a/apps/monolith/src/ContosoUniversity.Domain/Instructor/Instructor.cs
+++ b/apps/monolith/src/ContosoUniversity.Domain/Instructor/Instructor.cs
@@ -10,7 +10,9 @@ public class Instructor : IIdentifiable<Guid>
     public const int LastNameMaxLength = 50;
     public const int LastNameMinLength = 1;
 
+#pragma warning disable IDE0052
     private OfficeAssignment _officeAssignment;
+#pragma warning restore IDE0052
 
     private Instructor(
         string firstName,

--- a/apps/mservices/.editorconfig
+++ b/apps/mservices/.editorconfig
@@ -57,9 +57,13 @@ csharp_preserve_single_line_blocks = true
 
 # Language and unnecessary rules
 # https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/language-rules
+dotnet_diagnostic.IDE0001.severity = error # Simplify name
+dotnet_diagnostic.IDE0002.severity = error # Simplify member access
 dotnet_diagnostic.IDE0005.severity = error # Remove unnecessary using directives
 dotnet_diagnostic.IDE0011.severity = error # Add braces
 dotnet_diagnostic.IDE0044.severity = error # Add readonly modifier
+dotnet_diagnostic.IDE0051.severity = error # Remove unused private members
+dotnet_diagnostic.IDE0052.severity = error # Remove unread private member
 dotnet_diagnostic.IDE0290.severity = error # Use primary constructor
 
 [*.json]

--- a/apps/mservices/.editorconfig
+++ b/apps/mservices/.editorconfig
@@ -11,6 +11,9 @@ insert_final_newline = true
 indent_style = space
 indent_size = 4
 
+[*.json]
+indent_size = 2
+
 #########################################################################
 #   .NET Rules
 #########################################################################
@@ -66,5 +69,7 @@ dotnet_diagnostic.IDE0051.severity = error # Remove unused private members
 dotnet_diagnostic.IDE0052.severity = error # Remove unread private member
 dotnet_diagnostic.IDE0290.severity = error # Use primary constructor
 
-[*.json]
-indent_size = 2
+# Global suppressions
+
+# AnalysisMode: Default
+dotnet_diagnostic.CS1591.severity = none # Missing XML comment for publicly visible type or member

--- a/apps/mservices/Directory.Build.props
+++ b/apps/mservices/Directory.Build.props
@@ -6,6 +6,12 @@
 
     <PropertyGroup>
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+        <AnalysisMode>Default</AnalysisMode>
+        <AnalysisLevel>latest</AnalysisLevel>
+        <CodeAnalysisTreatWarningsAsErrors>true</CodeAnalysisTreatWarningsAsErrors>
+        <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
+        <GenerateDocumentationFile>true</GenerateDocumentationFile>
+        <NoWarn>CS1591</NoWarn>
     </PropertyGroup>
 
 </Project>

--- a/apps/mservices/Directory.Build.props
+++ b/apps/mservices/Directory.Build.props
@@ -7,11 +7,10 @@
     <PropertyGroup>
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
         <AnalysisMode>Default</AnalysisMode>
-        <AnalysisLevel>latest</AnalysisLevel>
+        <AnalysisLevel>10.0</AnalysisLevel>
         <CodeAnalysisTreatWarningsAsErrors>true</CodeAnalysisTreatWarningsAsErrors>
         <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
-        <NoWarn>CS1591</NoWarn>
     </PropertyGroup>
 
 </Project>

--- a/apps/mservices/src/Courses.Data.Writes/Courses.Data.Writes.csproj
+++ b/apps/mservices/src/Courses.Data.Writes/Courses.Data.Writes.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <NoWarn>1701;1702;CS8981</NoWarn>
+        <NoWarn>$(NoWarn);CS8981</NoWarn>
     </PropertyGroup>
 
     <ItemGroup>

--- a/apps/mservices/src/Departments.Data.Writes/Departments.Data.Writes.csproj
+++ b/apps/mservices/src/Departments.Data.Writes/Departments.Data.Writes.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <NoWarn>1701;1702;CS8981</NoWarn>
+        <NoWarn>$(NoWarn);CS8981</NoWarn>
     </PropertyGroup>
 
     <ItemGroup>

--- a/apps/mservices/src/Students.Data.Writes/Students.Data.Writes.csproj
+++ b/apps/mservices/src/Students.Data.Writes/Students.Data.Writes.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <NoWarn>1701;1702;CS8981</NoWarn>
+        <NoWarn>$(NoWarn);CS8981</NoWarn>
     </PropertyGroup>
 
     <ItemGroup>


### PR DESCRIPTION
### References
- https://learn.microsoft.com/en-us/dotnet/core/project-sdk/msbuild-props#code-analysis-properties

This pull request introduces stricter code analysis and style enforcement across both the `monolith` and `mservices` solutions, updates project configurations to centralize warning suppression, and makes a targeted code change to suppress a new analyzer warning. These changes aim to improve code quality, maintain consistency, and prepare for future .NET updates.

**Code analysis and style enforcement:**

* Both `apps/monolith/Directory.Build.props` and `apps/mservices/Directory.Build.props` now enforce the latest code analysis rules, treat code analysis warnings as errors, require code style enforcement during builds, and generate XML documentation files.
* `.editorconfig` files in both `apps/monolith` and `apps/mservices` have been updated to treat several code style issues as errors, including simplified names, simplified member access, removal of unused or unread private members, and others. The `dotnet_diagnostic.CS1591.severity = none` property is set to suppress missing XML comment warnings (**CS1591**).

**Project configuration improvements:**

* Project files for data write libraries in both solutions now reference the centralized `NoWarn` property, reducing duplication and ensuring consistent warning suppression.

**Code changes for analyzer compatibility:**

* In `Instructor.cs`, a pragma directive disables the `IDE0052` warning for the unused private field `_officeAssignment`, ensuring the code builds cleanly under the stricter analyzer settings.