### PR TITLE
CONTOSO: Upgrade to `AnalysisMode=Minimum`

### DIFF
--- a/apps/monolith/.editorconfig
+++ b/apps/monolith/.editorconfig
@@ -82,3 +82,7 @@ dotnet_diagnostic.IDE0290.severity = error # Use primary constructor
 
 # AnalysisMode: Default
 dotnet_diagnostic.CS1591.severity = none # Missing XML comment for publicly visible type or member
+
+# AnalysisMode: Minimum
+dotnet_diagnostic.CA1859.severity = none # Use concrete types when possible for improved performance
+dotnet_diagnostic.CA1861.severity = none # Avoid constant arrays as arguments

--- a/apps/monolith/Directory.Build.props
+++ b/apps/monolith/Directory.Build.props
@@ -6,7 +6,7 @@
 
     <PropertyGroup>
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-        <AnalysisMode>Default</AnalysisMode>
+        <AnalysisMode>Minimum</AnalysisMode>
         <AnalysisLevel>10.0</AnalysisLevel>
         <CodeAnalysisTreatWarningsAsErrors>true</CodeAnalysisTreatWarningsAsErrors>
         <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>

--- a/apps/monolith/src/ContosoUniversity.Application/Services/CrossContextBoundariesValidator.cs
+++ b/apps/monolith/src/ContosoUniversity.Application/Services/CrossContextBoundariesValidator.cs
@@ -24,7 +24,7 @@ public static class CrossContextBoundariesValidator
         HashSet<Guid> referencedDepartmentIds = courses.Select(x => x.DepartmentId).ToHashSet();
         Guid[] notFoundDepartments = referencedDepartmentIds.Except(existingDepartmentIds).ToArray();
 
-        if (notFoundDepartments.Any())
+        if (notFoundDepartments.Length != 0)
         {
             throw new Exception(
                 $"Unbound contexts inconsistency. Departments not found: {notFoundDepartments.ToDisplayString()}.");
@@ -42,7 +42,7 @@ public static class CrossContextBoundariesValidator
         HashSet<Guid> existingCourseIds = courses.Select(x => x.ExternalId).ToHashSet();
         Guid[] notFoundCourses = referencedCourseIds.Except(existingCourseIds).ToArray();
 
-        if (notFoundCourses.Any())
+        if (notFoundCourses.Length != 0)
         {
             throw new Exception(
                 $"Unbound contexts inconsistency. Course not found: {notFoundCourses.ToDisplayString()}.");
@@ -60,7 +60,7 @@ public static class CrossContextBoundariesValidator
         HashSet<Guid> existingCourseIds = courses.Select(x => x.ExternalId).ToHashSet();
         Guid[] notFoundCourses = referencedCourseIds.Except(existingCourseIds).ToArray();
 
-        if (notFoundCourses.Any())
+        if (notFoundCourses.Length != 0)
         {
             throw new Exception(
                 $"Unbound contexts inconsistency. Course not found: {notFoundCourses.ToDisplayString()}.");

--- a/apps/monolith/src/ContosoUniversity.Application/Services/Departments/Commands/DeleteDepartmentCommand.cs
+++ b/apps/monolith/src/ContosoUniversity.Application/Services/Departments/Commands/DeleteDepartmentCommand.cs
@@ -37,7 +37,7 @@ internal class DeleteDepartmentCommandHandler(
          * - withdraw enrolled students
          * - remove related assignments (restrain assigned instructors)
          */
-        if (relatedCoursesIds.Any())
+        if (relatedCoursesIds.Length != 0)
         {
             await mediator.Publish(
                 new DepartmentDeletedNotification(relatedCoursesIds),

--- a/apps/monolith/src/ContosoUniversity.Application/Services/Students/Notifications/CourseDeletedNotificationHandler.cs
+++ b/apps/monolith/src/ContosoUniversity.Application/Services/Students/Notifications/CourseDeletedNotificationHandler.cs
@@ -1,7 +1,6 @@
 namespace ContosoUniversity.Application.Services.Students.Notifications;
 
 using System;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -23,7 +22,7 @@ internal class CourseDeletedNotificationHandler(IStudentsRwRepository studentsRe
         Student[] enrolledStudents = await studentsRepository
             .GetStudentsEnrolledForCourses(courseIds, cancellationToken);
 
-        if (enrolledStudents.Any())
+        if (enrolledStudents.Length != 0)
         {
             foreach (Student student in enrolledStudents)
             {

--- a/apps/monolith/src/ContosoUniversity.Application/Services/Students/Queries/GetStudentDetailsQuery.cs
+++ b/apps/monolith/src/ContosoUniversity.Application/Services/Students/Queries/GetStudentDetailsQuery.cs
@@ -42,7 +42,7 @@ internal class GetStudentDetailsQueryHandler(
             .GetCourseTitlesReference(coursesIds, cancellationToken);
 
         Guid[] notFoundCourseIds = coursesIds.Except(courseTitles.Keys).ToArray();
-        if (notFoundCourseIds.Any())
+        if (notFoundCourseIds.Length != 0)
         {
             throw new AggregateException(notFoundCourseIds
                 .Select(x => new EntityNotFoundException("course", x)));

--- a/apps/monolith/src/ContosoUniversity.Application/ValidationBehavior.cs
+++ b/apps/monolith/src/ContosoUniversity.Application/ValidationBehavior.cs
@@ -41,6 +41,6 @@ public class ValidationBehavior<TRequest, TResponse>(
             }
         }
 
-        return await next();
+        return await next(cancellationToken);
     }
 }

--- a/apps/monolith/src/ContosoUniversity.Data.Students.Reads/ReadOnlyRepository.cs
+++ b/apps/monolith/src/ContosoUniversity.Data.Students.Reads/ReadOnlyRepository.cs
@@ -25,9 +25,11 @@ internal sealed class ReadOnlyRepository(ReadOnlyContext dbContext) : EfRoReposi
             await conn.OpenAsync(cancellationToken);
             await using DbCommand command = conn.CreateCommand();
             command.CommandText =
-                @"SELECT EnrollmentDate, COUNT(*) AS StudentCount
-                      FROM [std].Student
-                      GROUP BY EnrollmentDate";
+"""
+SELECT EnrollmentDate, COUNT(*) AS StudentCount
+FROM [std].Student
+GROUP BY EnrollmentDate
+""";
             DbDataReader reader = await command.ExecuteReaderAsync(cancellationToken);
 
             if (reader.HasRows)
@@ -82,7 +84,7 @@ internal sealed class ReadOnlyRepository(ReadOnlyContext dbContext) : EfRoReposi
             pageInfo);
     }
 
-    private IQueryable<Student> ApplySearch(IQueryable<Student> source, SearchRequest request)
+    private static IQueryable<Student> ApplySearch(IQueryable<Student> source, SearchRequest request)
     {
         return string.IsNullOrEmpty(request.SearchString)
             ? source
@@ -91,7 +93,7 @@ internal sealed class ReadOnlyRepository(ReadOnlyContext dbContext) : EfRoReposi
                      || s.FirstName.Contains(request.SearchString));
     }
 
-    private IQueryable<Student> ApplyOrder(IQueryable<Student> source, OrderRequest request)
+    private static IQueryable<Student> ApplyOrder(IQueryable<Student> source, OrderRequest request)
     {
         return request.SortOrder switch
         {

--- a/apps/monolith/src/ContosoUniversity.Domain/Instructor/Instructor.cs
+++ b/apps/monolith/src/ContosoUniversity.Domain/Instructor/Instructor.cs
@@ -65,7 +65,7 @@ public class Instructor : IIdentifiable<Guid>
 
     public void ResetCourseAssignments()
     {
-        if (CourseAssignments.Any())
+        if (CourseAssignments.Count != 0)
         {
             CourseAssignments.Clear();
         }

--- a/apps/monolith/test/system/ContosoUniversity.SystemTests/CoursesController/EditCourseRequest.cs
+++ b/apps/monolith/test/system/ContosoUniversity.SystemTests/CoursesController/EditCourseRequest.cs
@@ -12,7 +12,7 @@ public record EditCourseRequest
     public int Credits { get; set; }
     public Guid DepartmentId { get; set; }
 
-    public static EditCourseRequest Valid = new()
+    public static readonly EditCourseRequest Valid = new()
     {
         Title = "Computers Algebra",
         Credits = 3,

--- a/apps/monolith/test/unit/ContosoUniversity.Domain.Tests/Instructor/CourseAssignmentsTests.cs
+++ b/apps/monolith/test/unit/ContosoUniversity.Domain.Tests/Instructor/CourseAssignmentsTests.cs
@@ -78,12 +78,12 @@ public class CourseAssignmentsTests
         });
     }
 
-    private Instructor CreateUnassignedInstructor()
+    private static Instructor CreateUnassignedInstructor()
     {
         return Instructor.Create(string.Empty, string.Empty, DateTime.Now);
     }
 
-    private Instructor CreateAssignedInstructor(params Guid[] assignments)
+    private static Instructor CreateAssignedInstructor(params Guid[] assignments)
     {
         Instructor instructor = CreateUnassignedInstructor();
 

--- a/apps/mservices/.editorconfig
+++ b/apps/mservices/.editorconfig
@@ -73,3 +73,9 @@ dotnet_diagnostic.IDE0290.severity = error # Use primary constructor
 
 # AnalysisMode: Default
 dotnet_diagnostic.CS1591.severity = none # Missing XML comment for publicly visible type or member
+
+# AnalysisMode: Minimum
+dotnet_diagnostic.CA1859.severity = none # Use concrete types when possible for improved performance
+dotnet_diagnostic.CA1861.severity = none # Avoid constant arrays as arguments
+dotnet_diagnostic.CA1869.severity = none # Cache and reuse 'JsonSerializerOptions' instances
+dotnet_diagnostic.CA1873.severity = none # Avoid potentially expensive logging

--- a/apps/mservices/Directory.Build.props
+++ b/apps/mservices/Directory.Build.props
@@ -6,7 +6,7 @@
 
     <PropertyGroup>
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-        <AnalysisMode>Default</AnalysisMode>
+        <AnalysisMode>Minimum</AnalysisMode>
         <AnalysisLevel>10.0</AnalysisLevel>
         <CodeAnalysisTreatWarningsAsErrors>true</CodeAnalysisTreatWarningsAsErrors>
         <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>

--- a/apps/mservices/src/ContosoUniversity.Application/CrossContextBoundariesValidator.cs
+++ b/apps/mservices/src/ContosoUniversity.Application/CrossContextBoundariesValidator.cs
@@ -21,7 +21,7 @@ public static class CrossContextBoundariesValidator
         HashSet<Guid> referencedDepartmentIds = courses.Select(x => x.DepartmentId).ToHashSet();
         Guid[] notFoundDepartments = referencedDepartmentIds.Except(existingDepartmentIds).ToArray();
 
-        if (notFoundDepartments.Any())
+        if (notFoundDepartments.Length != 0)
         {
             throw new Exception(
                 $"Unbound contexts inconsistency. Departments not found: {notFoundDepartments.ToDisplayString()}.");
@@ -39,7 +39,7 @@ public static class CrossContextBoundariesValidator
         HashSet<Guid> existingCourseIds = courses.Select(x => x.ExternalId).ToHashSet();
         Guid[] notFoundCourses = referencedCourseIds.Except(existingCourseIds).ToArray();
 
-        if (notFoundCourses.Any())
+        if (notFoundCourses.Length != 0)
         {
             throw new Exception(
                 $"Unbound contexts inconsistency. Course not found: {notFoundCourses.ToDisplayString()}.");
@@ -57,7 +57,7 @@ public static class CrossContextBoundariesValidator
         HashSet<Guid> existingCourseIds = courses.Select(x => x.ExternalId).ToHashSet();
         Guid[] notFoundCourses = referencedCourseIds.Except(existingCourseIds).ToArray();
 
-        if (notFoundCourses.Any())
+        if (notFoundCourses.Length != 0)
         {
             throw new Exception(
                 $"Unbound contexts inconsistency. Course not found: {notFoundCourses.ToDisplayString()}.");

--- a/apps/mservices/src/ContosoUniversity.Application/Students/Queries/GetStudentDetailsQuery.cs
+++ b/apps/mservices/src/ContosoUniversity.Application/Students/Queries/GetStudentDetailsQuery.cs
@@ -41,7 +41,7 @@ internal class GetStudentDetailsQueryHandler(
             .GetCourseTitlesReference(coursesIds, cancellationToken);
 
         Guid[] notFoundCourseIds = coursesIds.Except(courseTitles.Keys).ToArray();
-        if (notFoundCourseIds.Any())
+        if (notFoundCourseIds.Length != 0)
         {
             throw new AggregateException(notFoundCourseIds
                 .Select(x => new EntityNotFoundException("course", x)));

--- a/apps/mservices/src/ContosoUniversity.Application/ValidationBehavior.cs
+++ b/apps/mservices/src/ContosoUniversity.Application/ValidationBehavior.cs
@@ -41,6 +41,6 @@ public class ValidationBehavior<TRequest, TResponse>(
             }
         }
 
-        return await next();
+        return await next(cancellationToken);
     }
 }

--- a/apps/mservices/src/Departments.Core/Domain/Instructor.cs
+++ b/apps/mservices/src/Departments.Core/Domain/Instructor.cs
@@ -67,7 +67,7 @@ public class Instructor : IIdentifiable<Guid>
 
     public void ResetCourseAssignments()
     {
-        if (CourseAssignments.Any())
+        if (CourseAssignments.Count != 0)
         {
             CourseAssignments.Clear();
         }

--- a/apps/mservices/src/Students.Data.Reads/ReadOnlyRepository.cs
+++ b/apps/mservices/src/Students.Data.Reads/ReadOnlyRepository.cs
@@ -27,9 +27,11 @@ internal sealed class ReadOnlyRepository(ReadOnlyContext dbContext) : EfRoReposi
             await conn.OpenAsync(cancellationToken);
             await using DbCommand command = conn.CreateCommand();
             command.CommandText =
-                @"SELECT EnrollmentDate, COUNT(*) AS StudentCount
-                      FROM [std].Student
-                      GROUP BY EnrollmentDate";
+"""
+SELECT EnrollmentDate, COUNT(*) AS StudentCount
+FROM [std].Student
+GROUP BY EnrollmentDate
+""";
             DbDataReader reader = await command.ExecuteReaderAsync(cancellationToken);
 
             if (reader.HasRows)
@@ -84,7 +86,7 @@ internal sealed class ReadOnlyRepository(ReadOnlyContext dbContext) : EfRoReposi
             pageInfo);
     }
 
-    private IQueryable<Student> ApplySearch(IQueryable<Student> source, SearchRequest request)
+    private static IQueryable<Student> ApplySearch(IQueryable<Student> source, SearchRequest request)
     {
         return string.IsNullOrEmpty(request.SearchString)
             ? source
@@ -93,7 +95,7 @@ internal sealed class ReadOnlyRepository(ReadOnlyContext dbContext) : EfRoReposi
                      || s.FirstName.Contains(request.SearchString));
     }
 
-    private IQueryable<Student> ApplyOrder(IQueryable<Student> source, OrderRequest request)
+    private static IQueryable<Student> ApplyOrder(IQueryable<Student> source, OrderRequest request)
     {
         return request.SortOrder switch
         {

--- a/apps/mservices/test/system/ContosoUniversity.SystemTests/CoursesController/EditCourseRequest.cs
+++ b/apps/mservices/test/system/ContosoUniversity.SystemTests/CoursesController/EditCourseRequest.cs
@@ -12,7 +12,7 @@ public record EditCourseRequest
     public int Credits { get; set; }
     public Guid DepartmentId { get; set; }
 
-    public static EditCourseRequest Valid = new()
+    public static readonly EditCourseRequest Valid = new()
     {
         Title = "Computers Algebra",
         Credits = 3,

--- a/apps/mservices/test/unit/Departments.Core.Tests/Instructor/CourseAssignmentsTests.cs
+++ b/apps/mservices/test/unit/Departments.Core.Tests/Instructor/CourseAssignmentsTests.cs
@@ -78,12 +78,12 @@ public class CourseAssignmentsTests
         });
     }
 
-    private Instructor CreateUnassignedInstructor()
+    private static Instructor CreateUnassignedInstructor()
     {
         return Instructor.Create(string.Empty, string.Empty, DateTime.Now);
     }
 
-    private Instructor CreateAssignedInstructor(params Guid[] assignments)
+    private static Instructor CreateAssignedInstructor(params Guid[] assignments)
     {
         Instructor instructor = CreateUnassignedInstructor();
 


### PR DESCRIPTION
This pull request makes several consistency and code quality improvements across both the monolith and microservices projects. The main changes include standardizing the use of array length checks instead of LINQ's `Any()`, updating static analysis settings to use a stricter analysis mode with additional rules, and refactoring some methods and fields for clarity and best practices.

**Code Quality and Consistency Improvements:**

* Replaced all uses of `.Any()` with `.Length != 0` for array emptiness checks in validation, notification handlers, and domain logic across both monolith and microservices codebases. This ensures more consistent and potentially more performant checks. [[1]](diffhunk://#diff-ecf6094bf01fcf518fcbe592fde39d71eaf4df4f9a9bba550e74a554352753c7L27-R27) [[2]](diffhunk://#diff-ecf6094bf01fcf518fcbe592fde39d71eaf4df4f9a9bba550e74a554352753c7L45-R45) [[3]](diffhunk://#diff-ecf6094bf01fcf518fcbe592fde39d71eaf4df4f9a9bba550e74a554352753c7L63-R63) [[4]](diffhunk://#diff-64200c1aab831e7a500eceab41ce9305c0f0cbc3c1b350ddfeb36837be264d0bL40-R40) [[5]](diffhunk://#diff-536510c3e346aeacb2464816071632efe696a807b4abb13a605baef5a0473c3cL26-R25) [[6]](diffhunk://#diff-a977dbded783ecfa4a033ecd29fd28bae898722ec6dc8580ab509b18226ad587L45-R45) [[7]](diffhunk://#diff-329c1d490a1e5a032b3ec50fb901905e5e220d502f7e9075ca410af30fb35821L68-R68) [[8]](diffhunk://#diff-cb5faf2c64802cace7b2b2d146689bfad6bfb4ae17786449ca86997288763609L24-R24) [[9]](diffhunk://#diff-cb5faf2c64802cace7b2b2d146689bfad6bfb4ae17786449ca86997288763609L42-R42) [[10]](diffhunk://#diff-cb5faf2c64802cace7b2b2d146689bfad6bfb4ae17786449ca86997288763609L60-R60) [[11]](diffhunk://#diff-b74a12184a62ed8b54669d6082b85aa5d52f73308a12424a0386f359f52c3485L44-R44) [[12]](diffhunk://#diff-fd938829973a4491f334b31fc4ed77e98425c22cbcf991668f6323c5a4dd6289L70-R70)

* Made utility methods and fields static and/or readonly where appropriate, such as `ApplySearch`, `ApplyOrder`, and the `Valid` field in `EditCourseRequest`, to follow best practices and improve code clarity. [[1]](diffhunk://#diff-f83ebc548ca80e6a1d4a42fa3101009a9f9a2bf1f7e61ecada3117183e5c370fL85-R87) [[2]](diffhunk://#diff-f83ebc548ca80e6a1d4a42fa3101009a9f9a2bf1f7e61ecada3117183e5c370fL94-R96) [[3]](diffhunk://#diff-87bb0f500b3b7fe9ac57c050324e2acbf59c4fcb9e4b38faa02b98dad940a71cL15-R15) [[4]](diffhunk://#diff-d668dc69ba8168beb396df3dc9f091c91e5d0bbb091e1d2d7439e009a76bc88eL87-R87) [[5]](diffhunk://#diff-d668dc69ba8168beb396df3dc9f091c91e5d0bbb091e1d2d7439e009a76bc88eL96-R96) [[6]](diffhunk://#diff-87bb0f500b3b7fe9ac57c050324e2acbf59c4fcb9e4b38faa02b98dad940a71cL15-R15) [[7]](diffhunk://#diff-ec462af2959e9d1f98d3b9593d893f9ddeb8ad00f46dbde9e5f5bb3e8684dd4dL81-R86) [[8]](diffhunk://#diff-3d9377f69556e910617cb711b13fd622415b4b0a62a995d0ea75f18dbe334b71L81-R86)

**Static Analysis and Build Configuration:**

* Changed the analysis mode from `Default` to `Minimum` in `Directory.Build.props` for both monolith and microservices, and added or suppressed several new analyzer rules in `.editorconfig` files to fine-tune code analysis (including CA1859, CA1861, CA1869, CA1873). This helps catch more issues at build time and enforces stricter code standards. [[1]](diffhunk://#diff-8a9635e6bb64642191ee8241441c40fac871fdf81910459ef8ab13a124d6838cL9-R9) [[2]](diffhunk://#diff-7f78340d8bab89dc71b7ae38816eb065be17a9b93631d2efc655d8bcb491efc1R85-R88) [[3]](diffhunk://#diff-8a9635e6bb64642191ee8241441c40fac871fdf81910459ef8ab13a124d6838cL9-R9) [[4]](diffhunk://#diff-36f0ab68d8aeb4e4653cd265e874571879829291aafc5166004051f76ede0895R76-R81)

**Other Minor Improvements:**

* Updated the SQL command in `ReadOnlyRepository.cs` to use a multi-line string for improved readability.
* Fixed code style by removing unnecessary `using System.Linq;` directive.
* Ensured that the pipeline behavior's `next` delegate is always called with a cancellation token. [[1]](diffhunk://#diff-391a6105fa1090bfc573fd74f8b3081a5e2460a9b31cb038026e53ef99fc67d6L44-R44) [[2]](diffhunk://#diff-391a6105fa1090bfc573fd74f8b3081a5e2460a9b31cb038026e53ef99fc67d6L44-R44)