### PR TITLE
CONTOSO: Upgrade to `AnalysisMode=Recommended` (#228)

### DIFF
--- a/apps/monolith/.editorconfig
+++ b/apps/monolith/.editorconfig
@@ -86,3 +86,11 @@ dotnet_diagnostic.CS1591.severity = none # Missing XML comment for publicly visi
 # AnalysisMode: Minimum
 dotnet_diagnostic.CA1859.severity = none # Use concrete types when possible for improved performance
 dotnet_diagnostic.CA1861.severity = none # Avoid constant arrays as arguments
+
+# AnalysisMode: Recommended
+dotnet_diagnostic.CA1051.severity = none # Do not declare visible instance fields
+dotnet_diagnostic.CA1305.severity = none # Specify IFormatProvider
+dotnet_diagnostic.CA1707.severity = none # Identifiers should not contain underscores
+dotnet_diagnostic.CA1716.severity = none # Identifiers should not match keywords
+dotnet_diagnostic.CA1852.severity = none # Seal internal types
+dotnet_diagnostic.CA2201.severity = none # Do not raise reserved exception types

--- a/apps/monolith/Directory.Build.props
+++ b/apps/monolith/Directory.Build.props
@@ -6,7 +6,7 @@
 
     <PropertyGroup>
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-        <AnalysisMode>Minimum</AnalysisMode>
+        <AnalysisMode>Recommended</AnalysisMode>
         <AnalysisLevel>10.0</AnalysisLevel>
         <CodeAnalysisTreatWarningsAsErrors>true</CodeAnalysisTreatWarningsAsErrors>
         <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>

--- a/apps/mservices/.editorconfig
+++ b/apps/mservices/.editorconfig
@@ -79,3 +79,12 @@ dotnet_diagnostic.CA1859.severity = none # Use concrete types when possible for 
 dotnet_diagnostic.CA1861.severity = none # Avoid constant arrays as arguments
 dotnet_diagnostic.CA1869.severity = none # Cache and reuse 'JsonSerializerOptions' instances
 dotnet_diagnostic.CA1873.severity = none # Avoid potentially expensive logging
+
+# AnalysisMode: Recommended
+dotnet_diagnostic.CA1051.severity = none # Do not declare visible instance fields
+dotnet_diagnostic.CA1305.severity = none # Specify IFormatProvider
+dotnet_diagnostic.CA1707.severity = none # Identifiers should not contain underscores
+dotnet_diagnostic.CA1711.severity = none # Identifiers should not have incorrect suffix
+dotnet_diagnostic.CA1848.severity = none # Use the LoggerMessage delegates
+dotnet_diagnostic.CA1852.severity = none # Seal internal types
+dotnet_diagnostic.CA2201.severity = none # Do not raise reserved exception types

--- a/apps/mservices/Directory.Build.props
+++ b/apps/mservices/Directory.Build.props
@@ -6,7 +6,7 @@
 
     <PropertyGroup>
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-        <AnalysisMode>Minimum</AnalysisMode>
+        <AnalysisMode>Recommended</AnalysisMode>
         <AnalysisLevel>10.0</AnalysisLevel>
         <CodeAnalysisTreatWarningsAsErrors>true</CodeAnalysisTreatWarningsAsErrors>
         <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>


### PR DESCRIPTION
This pull request updates code analysis settings for both the `monolith` and `mservices` applications to use the **Recommended** analysis mode instead of "Minimum". It also adds new rule suppressions to their `.editorconfig` files to handle additional diagnostics that are now enabled under the recommended mode.

**Analysis mode changes:**

* Changed `<AnalysisMode>` from `Minimum` to `Recommended` in both `apps/monolith/Directory.Build.props` and `apps/mservices/Directory.Build.props`, enabling a broader set of code analysis rules.

**.editorconfig rule suppressions:**

* Added suppressions for new diagnostics triggered by the recommended analysis mode in `apps/monolith/.editorconfig`, including rules like `CA1051`, `CA1305`, `CA1707`, `CA1716`, `CA1852`, and `CA2201`.
* Added suppressions for new diagnostics in `apps/mservices/.editorconfig`, including `CA1051`, `CA1305`, `CA1707`, `CA1711`, `CA1848`, `CA1852`, and `CA2201`.