### PR TITLE
MSVC: Fix failing `Delete` tests (#237)

### DIFF
--- a/apps/mservices/src/ContosoUniversity.ApiClients/CoursesApiClient.cs
+++ b/apps/mservices/src/ContosoUniversity.ApiClients/CoursesApiClient.cs
@@ -44,7 +44,7 @@ internal class CoursesApiClient(HttpClient client) : ICoursesApiClient
         => await client.PutAsJsonAsync($"/api/courses/{model.Id}", model, cancellationToken);
 
     public async Task Delete(CourseDeleteModel model, CancellationToken cancellationToken)
-        => await client.DeleteAsync(new Uri($"/api/courses/{model.Id}"), cancellationToken);
+        => await client.DeleteAsync(new Uri($"/api/courses/{model.Id}", UriKind.Relative), cancellationToken);
 
     public async Task<int> UpdateCoursesCredits(int multiplier, CancellationToken cancellationToken)
     {

--- a/apps/mservices/src/ContosoUniversity.ApiClients/DepartmentsApiClient.cs
+++ b/apps/mservices/src/ContosoUniversity.ApiClients/DepartmentsApiClient.cs
@@ -36,7 +36,7 @@ internal class DepartmentsApiClient(HttpClient client) : IDepartmentsApiClient
         => await client.PutAsJsonAsync($"{ApiRoot}/{model.ExternalId}", model, cancellationToken);
 
     public async Task Delete(DepartmentDeleteModel model, CancellationToken cancellationToken)
-        => await client.DeleteAsync(new Uri($"{ApiRoot}/{model.Id}"), cancellationToken);
+        => await client.DeleteAsync(new Uri($"{ApiRoot}/{model.Id}", UriKind.Relative), cancellationToken);
 }
 
 file record DepartmentDto(

--- a/apps/mservices/src/ContosoUniversity.ApiClients/InstructorsApiClient.cs
+++ b/apps/mservices/src/ContosoUniversity.ApiClients/InstructorsApiClient.cs
@@ -36,7 +36,7 @@ internal class InstructorsApiClient(HttpClient client) : IInstructorsApiClient
         => await client.PutAsJsonAsync($"{ApiRoot}/{model.ExternalId}", model, cancellationToken);
 
     public async Task Delete(InstructorDeleteModel model, CancellationToken cancellationToken)
-        => await client.DeleteAsync(new Uri($"{ApiRoot}/{model.Id}"), cancellationToken);
+        => await client.DeleteAsync(new Uri($"{ApiRoot}/{model.Id}", UriKind.Relative), cancellationToken);
 }
 
 file record InstructorDto(

--- a/apps/mservices/src/ContosoUniversity.ApiClients/StudentsApiClient.cs
+++ b/apps/mservices/src/ContosoUniversity.ApiClients/StudentsApiClient.cs
@@ -64,7 +64,7 @@ internal class StudentsApiClient(HttpClient client) : IStudentsApiClient
         => await client.PutAsJsonAsync($"{ApiRoot}/{model.ExternalId}", model, cancellationToken);
 
     public async Task Delete(StudentDeleteModel model, CancellationToken cancellationToken)
-        => await client.DeleteAsync(new Uri($"{ApiRoot}/{model.Id}"), cancellationToken);
+        => await client.DeleteAsync(new Uri($"{ApiRoot}/{model.Id}", UriKind.Relative), cancellationToken);
 }
 
 file enum GradeDto


### PR DESCRIPTION
This pull request updates the `Delete` methods in multiple API client classes to ensure that all URIs are explicitly created as relative URIs. This change improves consistency and prevents potential issues with URI resolution.

**API client improvements:**

* Updated the `Delete` method in `CoursesApiClient` to use `UriKind.Relative` when constructing the URI for course deletion.
* Updated the `Delete` method in `DepartmentsApiClient` to use `UriKind.Relative` when constructing the URI for department deletion.
* Updated the `Delete` method in `InstructorsApiClient` to use `UriKind.Relative` when constructing the URI for instructor deletion.
* Updated the `Delete` method in `StudentsApiClient` to use `UriKind.Relative` when constructing the URI for student deletion.