### PR TITLE
CONTOSO: Resolve `Default`/`Minimum` suppressions (#230)

### DIFF
--- a/apps/monolith/.editorconfig
+++ b/apps/monolith/.editorconfig
@@ -81,7 +81,6 @@ dotnet_diagnostic.IDE0290.severity = error # Use primary constructor
 dotnet_diagnostic.CS1591.severity = none # Missing XML comment for publicly visible type or member
 
 # AnalysisMode: Minimum
-dotnet_diagnostic.CA1859.severity = none # Use concrete types when possible for improved performance
 dotnet_diagnostic.CA1861.severity = none # Avoid constant arrays as arguments
 
 # AnalysisMode: Recommended

--- a/apps/monolith/.editorconfig
+++ b/apps/monolith/.editorconfig
@@ -21,7 +21,6 @@ tab_width = 2
 [*.{tf,tfvars}]
 indent_size = 2
 tab_width = 2
-indent_style = space
 
 #########################################################################
 #   .NET Rules
@@ -79,8 +78,6 @@ dotnet_diagnostic.IDE0052.severity = error # Remove unread private member
 dotnet_diagnostic.IDE0290.severity = error # Use primary constructor
 
 # Global suppressions
-
-# AnalysisMode: Default
 dotnet_diagnostic.CS1591.severity = none # Missing XML comment for publicly visible type or member
 
 # AnalysisMode: Minimum

--- a/apps/monolith/.editorconfig
+++ b/apps/monolith/.editorconfig
@@ -80,9 +80,6 @@ dotnet_diagnostic.IDE0290.severity = error # Use primary constructor
 # Global suppressions
 dotnet_diagnostic.CS1591.severity = none # Missing XML comment for publicly visible type or member
 
-# AnalysisMode: Minimum
-dotnet_diagnostic.CA1861.severity = none # Avoid constant arrays as arguments
-
 # AnalysisMode: Recommended
 dotnet_diagnostic.CA1051.severity = none # Do not declare visible instance fields
 dotnet_diagnostic.CA1305.severity = none # Specify IFormatProvider

--- a/apps/monolith/Directory.Build.props
+++ b/apps/monolith/Directory.Build.props
@@ -13,4 +13,8 @@
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
     </PropertyGroup>
 
+    <PropertyGroup>
+        <WarningsNotAsErrors>NU1902</WarningsNotAsErrors>
+    </PropertyGroup>
+
 </Project>

--- a/apps/monolith/src/ContosoUniversity.Data.Courses.Writes/ContosoUniversity.Data.Courses.Writes.csproj
+++ b/apps/monolith/src/ContosoUniversity.Data.Courses.Writes/ContosoUniversity.Data.Courses.Writes.csproj
@@ -1,9 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-    <PropertyGroup>
-        <NoWarn>$(NoWarn);CS8981</NoWarn>
-    </PropertyGroup>
-
     <ItemGroup>
         <ProjectReference Include="..\ContosoUniversity.Data\ContosoUniversity.Data.csproj"/>
     </ItemGroup>

--- a/apps/monolith/src/ContosoUniversity.Data.Courses.Writes/Migrations/.editorconfig
+++ b/apps/monolith/src/ContosoUniversity.Data.Courses.Writes/Migrations/.editorconfig
@@ -1,0 +1,3 @@
+[*.cs]
+dotnet_diagnostic.CA1861.severity = none # Avoid constant arrays as arguments
+dotnet_diagnostic.CS8981.severity = none # The type name only contains lower-cased ascii characters

--- a/apps/monolith/src/ContosoUniversity.Data.Departments.Writes/ContosoUniversity.Data.Departments.Writes.csproj
+++ b/apps/monolith/src/ContosoUniversity.Data.Departments.Writes/ContosoUniversity.Data.Departments.Writes.csproj
@@ -1,9 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-    <PropertyGroup>
-        <NoWarn>$(NoWarn);CS8981</NoWarn>
-    </PropertyGroup>
-
     <ItemGroup>
         <ProjectReference Include="..\ContosoUniversity.Data\ContosoUniversity.Data.csproj"/>
     </ItemGroup>

--- a/apps/monolith/src/ContosoUniversity.Data.Departments.Writes/Migrations/.editorconfig
+++ b/apps/monolith/src/ContosoUniversity.Data.Departments.Writes/Migrations/.editorconfig
@@ -1,0 +1,3 @@
+[*.cs]
+dotnet_diagnostic.CA1861.severity = none # Avoid constant arrays as arguments
+dotnet_diagnostic.CS8981.severity = none # The type name only contains lower-cased ascii characters

--- a/apps/monolith/src/ContosoUniversity.Data.Students.Writes/ContosoUniversity.Data.Students.Writes.csproj
+++ b/apps/monolith/src/ContosoUniversity.Data.Students.Writes/ContosoUniversity.Data.Students.Writes.csproj
@@ -1,9 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-    <PropertyGroup>
-        <NoWarn>$(NoWarn);CS8981</NoWarn>
-    </PropertyGroup>
-
     <ItemGroup>
         <ProjectReference Include="..\ContosoUniversity.Data\ContosoUniversity.Data.csproj"/>
     </ItemGroup>

--- a/apps/monolith/src/ContosoUniversity.Data.Students.Writes/Migrations/.editorconfig
+++ b/apps/monolith/src/ContosoUniversity.Data.Students.Writes/Migrations/.editorconfig
@@ -1,0 +1,3 @@
+[*.cs]
+dotnet_diagnostic.CA1861.severity = none # Avoid constant arrays as arguments
+dotnet_diagnostic.CS8981.severity = none # The type name only contains lower-cased ascii characters

--- a/apps/monolith/test/system/ContosoUniversity.SystemTests/ServiceLocator.cs
+++ b/apps/monolith/test/system/ContosoUniversity.SystemTests/ServiceLocator.cs
@@ -14,7 +14,7 @@ public static class ServiceLocator
 
     private static readonly IServiceProvider ServiceProvider;
 
-    private static IServiceProvider BuildServiceProvider()
+    private static ServiceProvider BuildServiceProvider()
     {
         var services = new ServiceCollection();
 

--- a/apps/monolith/test/system/ContosoUniversity.SystemTests/ServiceLocator.cs
+++ b/apps/monolith/test/system/ContosoUniversity.SystemTests/ServiceLocator.cs
@@ -7,12 +7,9 @@ using Microsoft.Extensions.DependencyInjection;
 
 public static class ServiceLocator
 {
-    static ServiceLocator()
-    {
-        ServiceProvider = BuildServiceProvider();
-    }
+    static ServiceLocator() => _serviceProvider = BuildServiceProvider();
 
-    private static readonly IServiceProvider ServiceProvider;
+    private static readonly IServiceProvider _serviceProvider;
 
     private static ServiceProvider BuildServiceProvider()
     {
@@ -27,8 +24,5 @@ public static class ServiceLocator
         return services.BuildServiceProvider();
     }
 
-    public static T GetRequiredService<T>()
-    {
-        return ServiceProvider.GetRequiredService<T>();
-    }
+    public static T GetRequiredService<T>() => _serviceProvider.GetRequiredService<T>();
 }

--- a/apps/mservices/.editorconfig
+++ b/apps/mservices/.editorconfig
@@ -72,9 +72,6 @@ dotnet_diagnostic.IDE0290.severity = error # Use primary constructor
 # Global suppressions
 dotnet_diagnostic.CS1591.severity = none # Missing XML comment for publicly visible type or member
 
-# AnalysisMode: Minimum
-dotnet_diagnostic.CA1873.severity = none # Avoid potentially expensive logging
-
 # AnalysisMode: Recommended
 dotnet_diagnostic.CA1051.severity = none # Do not declare visible instance fields
 dotnet_diagnostic.CA1305.severity = none # Specify IFormatProvider

--- a/apps/mservices/.editorconfig
+++ b/apps/mservices/.editorconfig
@@ -73,7 +73,6 @@ dotnet_diagnostic.IDE0290.severity = error # Use primary constructor
 dotnet_diagnostic.CS1591.severity = none # Missing XML comment for publicly visible type or member
 
 # AnalysisMode: Minimum
-dotnet_diagnostic.CA1859.severity = none # Use concrete types when possible for improved performance
 dotnet_diagnostic.CA1861.severity = none # Avoid constant arrays as arguments
 dotnet_diagnostic.CA1869.severity = none # Cache and reuse 'JsonSerializerOptions' instances
 dotnet_diagnostic.CA1873.severity = none # Avoid potentially expensive logging

--- a/apps/mservices/.editorconfig
+++ b/apps/mservices/.editorconfig
@@ -70,8 +70,6 @@ dotnet_diagnostic.IDE0052.severity = error # Remove unread private member
 dotnet_diagnostic.IDE0290.severity = error # Use primary constructor
 
 # Global suppressions
-
-# AnalysisMode: Default
 dotnet_diagnostic.CS1591.severity = none # Missing XML comment for publicly visible type or member
 
 # AnalysisMode: Minimum

--- a/apps/mservices/.editorconfig
+++ b/apps/mservices/.editorconfig
@@ -73,7 +73,6 @@ dotnet_diagnostic.IDE0290.severity = error # Use primary constructor
 dotnet_diagnostic.CS1591.severity = none # Missing XML comment for publicly visible type or member
 
 # AnalysisMode: Minimum
-dotnet_diagnostic.CA1869.severity = none # Cache and reuse 'JsonSerializerOptions' instances
 dotnet_diagnostic.CA1873.severity = none # Avoid potentially expensive logging
 
 # AnalysisMode: Recommended

--- a/apps/mservices/.editorconfig
+++ b/apps/mservices/.editorconfig
@@ -73,7 +73,6 @@ dotnet_diagnostic.IDE0290.severity = error # Use primary constructor
 dotnet_diagnostic.CS1591.severity = none # Missing XML comment for publicly visible type or member
 
 # AnalysisMode: Minimum
-dotnet_diagnostic.CA1861.severity = none # Avoid constant arrays as arguments
 dotnet_diagnostic.CA1869.severity = none # Cache and reuse 'JsonSerializerOptions' instances
 dotnet_diagnostic.CA1873.severity = none # Avoid potentially expensive logging
 

--- a/apps/mservices/Directory.Build.props
+++ b/apps/mservices/Directory.Build.props
@@ -13,4 +13,8 @@
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
     </PropertyGroup>
 
+    <PropertyGroup>
+        <WarningsNotAsErrors>NU1902</WarningsNotAsErrors>
+    </PropertyGroup>
+
 </Project>

--- a/apps/mservices/src/Courses.Data.Writes/Courses.Data.Writes.csproj
+++ b/apps/mservices/src/Courses.Data.Writes/Courses.Data.Writes.csproj
@@ -1,9 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-    <PropertyGroup>
-        <NoWarn>$(NoWarn);CS8981</NoWarn>
-    </PropertyGroup>
-
     <ItemGroup>
         <ProjectReference Include="..\ContosoUniversity.Data\ContosoUniversity.Data.csproj"/>
         <ProjectReference Include="..\Courses.Core\Courses.Core.csproj" />

--- a/apps/mservices/src/Courses.Data.Writes/Migrations/.editorconfig
+++ b/apps/mservices/src/Courses.Data.Writes/Migrations/.editorconfig
@@ -1,0 +1,3 @@
+[*.cs]
+dotnet_diagnostic.CA1861.severity = none # Avoid constant arrays as arguments
+dotnet_diagnostic.CS8981.severity = none # The type name only contains lower-cased ascii characters

--- a/apps/mservices/src/Courses.Worker/DepartmentDeletedEventHandler.cs
+++ b/apps/mservices/src/Courses.Worker/DepartmentDeletedEventHandler.cs
@@ -8,7 +8,7 @@ using MassTransit;
 
 using MediatR;
 
-internal class DepartmentDeletedEventHandler(
+internal partial class DepartmentDeletedEventHandler(
     IMediator mediator,
     ICoursesRwRepository repository,
     ILogger<DepartmentDeletedEventHandler> logger)
@@ -16,9 +16,7 @@ internal class DepartmentDeletedEventHandler(
 {
     public async Task Consume(ConsumeContext<DepartmentDeletedEvent> context)
     {
-        logger.LogInformation(
-            "Removing courses for deleted department: {DepartmentId}",
-            context.Message.DepartmentId);
+        LogEntryPoint(context.Message.DepartmentId);
 
         Course[] courses = await repository.GetByDepartmentId(
             context.Message.DepartmentId,
@@ -36,4 +34,9 @@ internal class DepartmentDeletedEventHandler(
         // var tasks = commands.Select(x => mediator.Send(x, context.CancellationToken));
         // await Task.WhenAll(tasks);
     }
+
+    [LoggerMessage(
+        Level = LogLevel.Information,
+        Message = "Removing courses for deleted department: {DepartmentId}")]
+    private partial void LogEntryPoint(Guid departmentId);
 }

--- a/apps/mservices/src/Departments.Data.Writes/Departments.Data.Writes.csproj
+++ b/apps/mservices/src/Departments.Data.Writes/Departments.Data.Writes.csproj
@@ -1,9 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-    <PropertyGroup>
-        <NoWarn>$(NoWarn);CS8981</NoWarn>
-    </PropertyGroup>
-
     <ItemGroup>
         <ProjectReference Include="..\ContosoUniversity.Data\ContosoUniversity.Data.csproj"/>
         <ProjectReference Include="..\Departments.Core\Departments.Core.csproj" />

--- a/apps/mservices/src/Departments.Data.Writes/Migrations/.editorconfig
+++ b/apps/mservices/src/Departments.Data.Writes/Migrations/.editorconfig
@@ -1,0 +1,3 @@
+[*.cs]
+dotnet_diagnostic.CA1861.severity = none # Avoid constant arrays as arguments
+dotnet_diagnostic.CS8981.severity = none # The type name only contains lower-cased ascii characters

--- a/apps/mservices/src/Departments.Worker/CourseDeletedEventHandler.cs
+++ b/apps/mservices/src/Departments.Worker/CourseDeletedEventHandler.cs
@@ -5,7 +5,7 @@ using Departments.Core.Domain;
 
 using MassTransit;
 
-internal class CourseDeletedEventHandler(
+internal partial class CourseDeletedEventHandler(
     IInstructorsRwRepository repository,
     ILogger<CourseDeletedEventHandler> logger)
     : IConsumer<CourseDeletedEvent>
@@ -14,15 +14,14 @@ internal class CourseDeletedEventHandler(
     {
         Guid courseId = context.Message.Id;
 
-        logger.LogInformation("Reset instructor assignments for course: {Id}", courseId);
+        LogEntryPoint(courseId);
 
         Instructor[] instructors = await repository.GetAllAssignedToCourses(
             [courseId],
             context.CancellationToken);
 
-        logger.LogInformation(
-            "Instructors to have assignment reset: {InstructorIds}.",
-            string.Join(", ", instructors.Select(x => x.ExternalId)));
+        var ids = string.Join(", ", instructors.Select(x => x.ExternalId));
+        LogInstructorsFound(ids);
 
         foreach (Instructor instructor in instructors)
         {
@@ -30,4 +29,14 @@ internal class CourseDeletedEventHandler(
             await repository.Save(instructor, context.CancellationToken);
         }
     }
+
+    [LoggerMessage(
+        Level = LogLevel.Information,
+        Message = "Reset instructor assignments for course: {Id}")]
+    private partial void LogEntryPoint(Guid id);
+
+    [LoggerMessage(
+        Level = LogLevel.Information,
+        Message = "Instructors having assignments to reset: {Ids}")]
+    private partial void LogInstructorsFound(string ids);
 }

--- a/apps/mservices/src/Students.Data.Writes/Migrations/.editorconfig
+++ b/apps/mservices/src/Students.Data.Writes/Migrations/.editorconfig
@@ -1,0 +1,3 @@
+[*.cs]
+dotnet_diagnostic.CA1861.severity = none # Avoid constant arrays as arguments
+dotnet_diagnostic.CS8981.severity = none # The type name only contains lower-cased ascii characters

--- a/apps/mservices/src/Students.Data.Writes/Students.Data.Writes.csproj
+++ b/apps/mservices/src/Students.Data.Writes/Students.Data.Writes.csproj
@@ -1,9 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-    <PropertyGroup>
-        <NoWarn>$(NoWarn);CS8981</NoWarn>
-    </PropertyGroup>
-
     <ItemGroup>
         <ProjectReference Include="..\ContosoUniversity.Data\ContosoUniversity.Data.csproj"/>
         <ProjectReference Include="..\Students.Core\Students.Core.csproj" />

--- a/apps/mservices/src/Students.Worker/CourseDeletedEventHandler.cs
+++ b/apps/mservices/src/Students.Worker/CourseDeletedEventHandler.cs
@@ -5,7 +5,7 @@ using MassTransit;
 using Students.Core;
 using Students.Core.Domain;
 
-internal class CourseDeletedEventHandler(
+internal partial class CourseDeletedEventHandler(
     IStudentsRwRepository repository,
     ILogger<CourseDeletedEventHandler> logger)
     : IConsumer<CourseDeletedEvent>
@@ -14,15 +14,14 @@ internal class CourseDeletedEventHandler(
     {
         Guid courseId = context.Message.Id;
 
-        logger.LogInformation("Withdraw enrolled students for course: {Id}", courseId);
+        LogEntryPoint(courseId);
 
         Student[] students = await repository.GetStudentsEnrolledForCourses(
             [courseId],
             context.CancellationToken);
 
-        logger.LogInformation(
-            "Students to be withdrawn from course: {StudentIds}.",
-            string.Join(", ", students.Select(x => x.ExternalId)));
+        var ids = string.Join(", ", students.Select(x => x.ExternalId));
+        LogStudentsFound(ids);
 
         foreach (Student student in students)
         {
@@ -30,4 +29,14 @@ internal class CourseDeletedEventHandler(
             await repository.Save(student, context.CancellationToken);
         }
     }
+
+    [LoggerMessage(
+        Level = LogLevel.Information,
+        Message = "Withdraw enrolled students for course: {Id}")]
+    private partial void LogEntryPoint(Guid id);
+
+    [LoggerMessage(
+        Level = LogLevel.Information,
+        Message = "Students to be withdrawn from course: {Ids}")]
+    private partial void LogStudentsFound(string ids);
 }

--- a/apps/mservices/test/integration/Courses.Worker.IntegrationTests/DepartmentDeletedEventHandlerTests.cs
+++ b/apps/mservices/test/integration/Courses.Worker.IntegrationTests/DepartmentDeletedEventHandlerTests.cs
@@ -18,7 +18,7 @@ public class DepartmentDeletedEventHandlerTests :
     IClassFixture<MsSqlContext>,
     IClassFixture<RabbitMqContext>
 {
-    private const int ProcessingTimeSlot = 500;
+    private const int ProcessingTimeSlot = 1000;
 
     private readonly ITestHarness _testHarness;
     private readonly DbContextFactory _dbContextFactory;

--- a/apps/mservices/test/integration/Departments.Worker.IntegrationTests/CourseDeletedEventHandlerTests.cs
+++ b/apps/mservices/test/integration/Departments.Worker.IntegrationTests/CourseDeletedEventHandlerTests.cs
@@ -18,7 +18,7 @@ public class CourseDeletedEventHandlerTests :
     IClassFixture<MsSqlContext>,
     IClassFixture<RabbitMqContext>
 {
-    private const int ProcessingTimeSlot = 500;
+    private const int ProcessingTimeSlot = 1000;
 
     private readonly ITestHarness _testHarness;
     private readonly DbContextFactory _dbContextFactory;

--- a/apps/mservices/test/integration/IntegrationTesting.SharedKernel/RabbitMqClient.cs
+++ b/apps/mservices/test/integration/IntegrationTesting.SharedKernel/RabbitMqClient.cs
@@ -11,16 +11,23 @@ public class RabbitMqClient(string connectionString)
 {
     private readonly ConnectionFactory _factory = new() { Uri = new Uri(connectionString) };
 
+    private static readonly JsonSerializerOptions CamelCaseOptions = new JsonSerializerOptions
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+    };
+
+    private static readonly JsonSerializerOptions PropertyCaseInsensitiveOptions = new JsonSerializerOptions
+    {
+        PropertyNameCaseInsensitive = true
+    };
+
     public async Task PublishAsync<TMessage>(string queueName, TMessage message) where TMessage : class
     {
         await using var connection = await _factory.CreateConnectionAsync();
         await using var channel = await connection.CreateChannelAsync();
 
         var envelope = new MessageEnvelope<TMessage> { Message = message };
-        var bodyJson = JsonSerializer.Serialize(envelope, new JsonSerializerOptions
-        {
-            PropertyNamingPolicy = JsonNamingPolicy.CamelCase
-        });
+        var bodyJson = JsonSerializer.Serialize(envelope, CamelCaseOptions);
         var body = Encoding.UTF8.GetBytes(bodyJson);
 
         await channel.BasicPublishAsync(
@@ -45,11 +52,7 @@ public class RabbitMqClient(string connectionString)
                 var bodyJson = Encoding.UTF8.GetString(body);
                 Console.WriteLine($"Received raw message: {bodyJson}");
 
-                var envelope = JsonSerializer.Deserialize<MessageEnvelope<TMessage>>(bodyJson, new JsonSerializerOptions
-                {
-                    PropertyNameCaseInsensitive = true
-                });
-
+                var envelope = JsonSerializer.Deserialize<MessageEnvelope<TMessage>>(bodyJson, PropertyCaseInsensitiveOptions);
                 if (envelope?.Message is { } message)
                 {
                     tcs.TrySetResult(message);

--- a/apps/mservices/test/system/ContosoUniversity.SystemTests/ServiceLocator.cs
+++ b/apps/mservices/test/system/ContosoUniversity.SystemTests/ServiceLocator.cs
@@ -14,7 +14,7 @@ public static class ServiceLocator
 
     private static readonly IServiceProvider ServiceProvider;
 
-    private static IServiceProvider BuildServiceProvider()
+    private static ServiceProvider BuildServiceProvider()
     {
         var services = new ServiceCollection();
 

--- a/apps/mservices/test/system/ContosoUniversity.SystemTests/ServiceLocator.cs
+++ b/apps/mservices/test/system/ContosoUniversity.SystemTests/ServiceLocator.cs
@@ -7,12 +7,9 @@ using Microsoft.Extensions.DependencyInjection;
 
 public static class ServiceLocator
 {
-    static ServiceLocator()
-    {
-        ServiceProvider = BuildServiceProvider();
-    }
+    static ServiceLocator() => _serviceProvider = BuildServiceProvider();
 
-    private static readonly IServiceProvider ServiceProvider;
+    private static readonly IServiceProvider _serviceProvider;
 
     private static ServiceProvider BuildServiceProvider()
     {
@@ -27,8 +24,5 @@ public static class ServiceLocator
         return services.BuildServiceProvider();
     }
 
-    public static T GetRequiredService<T>()
-    {
-        return ServiceProvider.GetRequiredService<T>();
-    }
+    public static T GetRequiredService<T>() => _serviceProvider.GetRequiredService<T>();
 }


### PR DESCRIPTION
This pull request introduces several improvements to logging practices, code style configuration, and project file management across both the monolith and microservices solutions. The most significant changes include refactoring event handler logging to use source generators, consolidating and relocating code analysis suppressions, and cleaning up project files by removing redundant warning suppressions.

### Logging improvements

* Refactored logging in event handlers to use source-generated logging methods via `LoggerMessage` attributes, improving performance and structure in `DepartmentDeletedEventHandler`, `CourseDeletedEventHandler`, and `CourseDeletedEventHandler` classes. [[1]](diffhunk://#diff-df41a5a499387f1786e554c990f712c0671c6e2160f13ad7504f155f19ca9febL11-R19) [[2]](diffhunk://#diff-df41a5a499387f1786e554c990f712c0671c6e2160f13ad7504f155f19ca9febR37-R41) [[3]](diffhunk://#diff-1e869dcfd075fc45d6574b6a78b8822c11e5a2b1ea577e18cd0e399ac6edef29L8-R8) [[4]](diffhunk://#diff-1e869dcfd075fc45d6574b6a78b8822c11e5a2b1ea577e18cd0e399ac6edef29L17-R41) [[5]](diffhunk://#diff-cd54a9117b99b8f5edcbbaeebcd0056cc8c7cffdf16e8714be2e0a96493025ccL8-R8) [[6]](diffhunk://#diff-cd54a9117b99b8f5edcbbaeebcd0056cc8c7cffdf16e8714be2e0a96493025ccL17-R41)

### Code analysis and style configuration

* Moved code analysis suppressions for `CA1861` and `CS8981` from project files to `.editorconfig` files within the `Migrations` folders, centralizing configuration and reducing project file clutter.
* Removed redundant or unnecessary code analysis suppressions from solution-level `.editorconfig` files, specifically for rules that are now handled at the folder level. [[1]](diffhunk://#diff-7f78340d8bab89dc71b7ae38816eb065be17a9b93631d2efc655d8bcb491efc1L82-L89) [[2]](diffhunk://#diff-36f0ab68d8aeb4e4653cd265e874571879829291aafc5166004051f76ede0895L73-L82)

### Project file cleanup

* Removed `<NoWarn>` property groups from several `.csproj` files now that suppressions are handled in `.editorconfig`. [[1]](diffhunk://#diff-66c6034bb79ee900e558feff94aee0997b311cce53a0f09e96f4436f459d2470L3-L6) [[2]](diffhunk://#diff-c34fb9ecc527f7f93dab05c8fb9c9a81ff39295fe15a6027f2b634d1b99c5108L3-L6) [[3]](diffhunk://#diff-1bf97765172d9cfcd87d0b2ccf8803140caed3f58e1bfc4e870f0dc59a29d419L3-L6) [[4]](diffhunk://#diff-0723e3a531455b3f38726544216adfd6e602c68a25e5c20f7652b12b59aacbcbL3-L6)
* Added `<WarningsNotAsErrors>NU1902</WarningsNotAsErrors>` to `Directory.Build.props` files to prevent NuGet warning NU1902 from failing builds.

### Minor code and configuration updates

* Changed the return type of `BuildServiceProvider` in `ServiceLocator.cs` from `IServiceProvider` to the concrete `ServiceProvider` type.
* Minor `.editorconfig` cleanup (e.g., removing unnecessary `indent_style` line).