### PR TITLE
docs: add repository and architecture READMEs

### DIFF
--- a/.ai/README.md
+++ b/.ai/README.md
@@ -1,0 +1,22 @@
+# AI assistant guidance
+
+This directory contains skill files for AI-assisted work on the Contoso University repository.
+
+The goal is to make tools like GitHub Copilot, Codex, ChatGPT, and other coding agents behave consistently when analyzing, modifying, documenting, testing, or reviewing the repository.
+
+## Skill files
+
+- `skills/code-analysis.md` — how to inspect and reason about repository code.
+- `skills/documentation.md` — documentation style and README rules.
+- `skills/monolith.md` — guidance for `apps/monolith`.
+- `skills/mservices.md` — guidance for `apps/mservices`.
+- `skills/testing.md` — testing conventions and expectations.
+- `skills/docker-compose.md` — Docker Compose and local runtime guidance.
+- `skills/ci-github-actions.md` — GitHub Actions workflow guidance.
+- `skills/deployment-aws-ecs.md` — monolith AWS ECS/Fargate deployment guidance.
+
+## Core principle
+
+All architectural and implementation conclusions must be based on the current repository code.
+
+Do not assume behavior from framework conventions when the implementation can be inspected.

--- a/.ai/skills/ci-github-actions.md
+++ b/.ai/skills/ci-github-actions.md
@@ -1,0 +1,107 @@
+# GitHub Actions skill
+
+Use this skill when creating, changing, or reviewing GitHub Actions workflows.
+
+## General principles
+
+Keep monolith and microservices workflows separate unless there is a clear reason to share logic.
+
+Respect path filters.
+
+Avoid triggering expensive workflows for unrelated changes.
+
+Prefer explicit working directories based on repository variables.
+
+## Existing solution path variables
+
+The repository uses variables such as:
+
+```text
+MONOLITH_SLN_PATH
+MSERVICES_SLN_PATH
+```
+
+Use the appropriate one for each implementation.
+
+## Monolith PR checks
+
+The monolith PR-check workflow is scoped to changes under:
+
+```text
+apps/monolith/**
+database/**
+.github/**
+```
+
+It performs:
+
+- checkout;
+- .NET setup;
+- restore;
+- build;
+- unit tests;
+- format checks;
+- integration tests.
+
+## Microservices PR checks
+
+The microservices PR-check workflow is scoped to changes under:
+
+```text
+apps/mservices/**
+database/**
+.github/**
+```
+
+It performs:
+
+- checkout;
+- .NET setup;
+- restore;
+- build;
+- unit tests;
+- format checks;
+- integration tests for MVC, APIs, and workers.
+
+## Formatting
+
+The repository uses strict formatting/analyzer checks.
+
+Expected commands include:
+
+```bash
+dotnet format whitespace --no-restore --exclude ./src/*/Migrations --verify-no-changes
+dotnet format style --no-restore --exclude ./src/*/Migrations --verify-no-changes
+dotnet format analyzers --no-restore --exclude ./src/*/Migrations --verify-no-changes
+```
+
+## Deployment workflows
+
+The monolith has deployment workflows for:
+
+- building and pushing Docker images;
+- running the QA AWS ECS/Fargate environment;
+- stopping the QA AWS ECS/Fargate environment.
+
+When working with deployment workflows, check:
+
+- image names;
+- tags;
+- registry login;
+- AWS credentials;
+- ECS task definition family;
+- container names;
+- service names;
+- cluster names;
+- desired counts;
+- wait flags.
+
+## Security
+
+Do not hardcode secrets in workflow files.
+
+Use GitHub Secrets or repository/environment variables.
+
+Do not expose credentials in logs.
+
+Use placeholders in documentation.

--- a/.ai/skills/code-analysis.md
+++ b/.ai/skills/code-analysis.md
@@ -1,0 +1,55 @@
+# Code analysis skill
+
+Use this skill when analyzing implementation details, architecture, dependencies, runtime behavior, CI, Docker, tests, or deployment.
+
+## Required behavior
+
+Before answering questions about the implementation, inspect the relevant files.
+
+Do not answer from memory or generic framework knowledge if the repository can be checked.
+
+Base conclusions on the current repository state.
+
+When analyzing a feature or component, identify:
+
+- the relevant solution;
+- the executable project;
+- related class libraries;
+- configuration files;
+- Docker Compose services;
+- tests;
+- CI workflows;
+- deployment files, if any.
+
+## Avoid
+
+Do not say that something is implemented unless it is visible in the repository.
+
+Do not describe intended architecture as actual architecture.
+
+Do not assume that a `.csproj` boundary is a runtime service boundary.
+
+Do not assume that a service is independently deployable unless there is evidence.
+
+Do not infer production-readiness from local Docker Compose.
+
+## When code is inconclusive
+
+If the repository does not contain enough information, say so explicitly.
+
+Use wording such as:
+
+- "I cannot confirm this from the current repository."
+- "The code shows X, but I do not see Y implemented."
+- "This appears to be intended, but I do not see the runtime wiring."
+- "The next files to check would be..."
+
+## Good output structure
+
+For analysis answers, prefer this order:
+
+1. What was checked.
+2. What the code shows.
+3. What conclusion follows.
+4. What remains uncertain.
+5. Suggested next step, if needed.

--- a/.ai/skills/deployment-aws-ecs.md
+++ b/.ai/skills/deployment-aws-ecs.md
@@ -1,0 +1,148 @@
+# AWS ECS deployment skill
+
+Use this skill when working with the monolith AWS ECS/Fargate deployment.
+
+## Scope
+
+This skill applies to:
+
+```text
+apps/monolith
+```
+
+The microservices implementation does not currently have an equivalent cloud deployment path in the repository.
+
+## Deployment model
+
+The monolith QA deployment uses:
+
+- GitHub Actions;
+- GitHub Container Registry;
+- Terraform;
+- AWS ECS/Fargate;
+- Application Load Balancer;
+- Route 53;
+- ACM certificate;
+- CloudWatch Logs;
+- EFS;
+- Cloud Map service discovery;
+- SQL Server container in ECS.
+
+## Artifact workflow
+
+The artifact workflow builds and pushes:
+
+```text
+ghcr.io/alexbohomol/cuweb
+ghcr.io/alexbohomol/mssql-migrator
+```
+
+Images are tagged with:
+
+- short Git SHA;
+- `latest` for the default branch.
+
+## Terraform environment
+
+Terraform environment:
+
+```text
+apps/monolith/iac/envs/qa-aws-ecs
+```
+
+Networking module:
+
+```text
+apps/monolith/iac/modules/networking
+```
+
+The default app name is:
+
+```text
+contoso-mnlth
+```
+
+The default AWS region is:
+
+```text
+eu-central-1
+```
+
+The default configured domain is:
+
+```text
+qa-aws-ecs.mnlth.university.contoso.name
+```
+
+## ECS services
+
+The environment defines ECS services for:
+
+```text
+contoso-mnlth-web-service
+contoso-mnlth-mssql-service
+```
+
+The database migrator is run as a one-off ECS task.
+
+## SQL Server
+
+SQL Server is deployed as a container in ECS/Fargate.
+
+Do not describe the current implementation as RDS.
+
+Cloud Map provides the internal database DNS name:
+
+```text
+mssql.contoso.local
+```
+
+## Web service
+
+The web service is exposed through an Application Load Balancer.
+
+The target group health check path is:
+
+```text
+/health/readiness
+```
+
+The web task mounts EFS for ASP.NET Core Data Protection keys at:
+
+```text
+/var/dpkeys
+```
+
+## Run workflow
+
+The run workflow can:
+
+- resolve image tag;
+- start SQL Server service;
+- run database migrator;
+- start or update web service;
+- set web desired count;
+- optionally update only the web service.
+
+## Stop workflow
+
+The stop workflow scales down:
+
+```text
+contoso-mnlth-web-service
+contoso-mnlth-mssql-service
+```
+
+to desired count `0`.
+
+## Safety rules
+
+Be careful with security group changes.
+
+Do not open public database access unless there is an explicit reason.
+
+Do not hardcode AWS credentials, database credentials, tokens, or certificate material.
+
+Use variables and secrets.
+
+If proposing production improvements, distinguish them from the current implementation.

--- a/.ai/skills/docker-compose.md
+++ b/.ai/skills/docker-compose.md
@@ -1,0 +1,119 @@
+# Docker Compose skill
+
+Use this skill when working with `docker-compose.yml`, `docker-compose.override.yml`, Dockerfiles, container health checks, local infrastructure, or integration/e2e runtime setup.
+
+## General principles
+
+Docker Compose is used as the local multi-container runtime.
+
+Preserve startup sequencing.
+
+Prefer explicit health checks over timing-based waits.
+
+Do not replace health checks with arbitrary sleeps.
+
+## Health checks
+
+Health checks should target container-internal ports, not host-mapped ports.
+
+For ASP.NET Core containers, prefer:
+
+```bash
+curl --fail http://localhost:80/health/readiness || exit 1
+```
+
+inside the container.
+
+Do not use host ports such as `10000` from inside the same container.
+
+## depends_on
+
+The repository intentionally uses Compose dependency conditions.
+
+Use:
+
+```yaml
+condition: service_healthy
+```
+
+for long-running dependencies such as SQL Server, RabbitMQ, APIs, and workers.
+
+Use:
+
+```yaml
+condition: service_completed_successfully
+```
+
+for one-off migrator/init containers.
+
+## Monolith runtime
+
+`apps/monolith/docker-compose.yml` includes:
+
+- `web`
+- `mssql`
+- `mssql-migrator`
+- `aspire-dashboard`
+
+The web service depends on:
+
+- healthy SQL Server;
+- completed migrator.
+
+## Microservices runtime
+
+`apps/mservices/docker-compose.yml` includes:
+
+- `web`
+- `courses-api`
+- `courses-worker`
+- `departments-api`
+- `departments-worker`
+- `students-api`
+- `students-worker`
+- `mssql`
+- `mssql-migrator`
+- `rabbitmq`
+
+The web service depends on healthy backend APIs and RabbitMQ.
+
+APIs and workers depend on SQL Server, migrator completion, and RabbitMQ.
+
+## Local startup
+
+Typical local startup:
+
+```bash
+docker compose up --build --wait
+```
+
+Typical shutdown:
+
+```bash
+docker compose down
+```
+
+Remove volumes only when a clean database/broker state is needed:
+
+```bash
+docker compose down -v
+```
+
+## Certificate handling
+
+Do not hardcode real secrets or certificate passwords in documentation or examples.
+
+Use placeholders where possible:
+
+```bash
+dotnet dev-certs https -ep cert.pfx -p <local-dev-certificate-password>
+```
+
+## Dockerfile changes
+
+When changing Dockerfiles:
+
+- preserve restore caching where possible;
+- ensure all referenced projects are copied before `dotnet restore`;
+- ensure runtime images contain tools required by health checks;
+- check the corresponding Docker Compose build context and Dockerfile path.

--- a/.ai/skills/docker-compose.md
+++ b/.ai/skills/docker-compose.md
@@ -106,7 +106,7 @@ Do not hardcode real secrets or certificate passwords in documentation or exampl
 Use placeholders where possible:
 
 ```bash
-dotnet dev-certs https -ep cert.pfx -p <local-dev-certificate-password>
+dotnet dev-certs https -ep cert.pfx -p Test1234!
 ```
 
 ## Dockerfile changes

--- a/.ai/skills/documentation.md
+++ b/.ai/skills/documentation.md
@@ -73,5 +73,5 @@ Do not document real secrets, real passwords, real tokens, or real credentials.
 When commands require sensitive values, use placeholders:
 
 ```bash
-dotnet dev-certs https -ep cert.pfx -p <local-dev-certificate-password>
+dotnet dev-certs https -ep cert.pfx -p Test1234!
 ```

--- a/.ai/skills/documentation.md
+++ b/.ai/skills/documentation.md
@@ -1,0 +1,77 @@
+# Documentation skill
+
+Use this skill when creating or updating README files, architecture notes, setup guides, deployment notes, PR descriptions, ADRs, or inline documentation.
+
+## Language
+
+Documentation must be written in English.
+
+Conversation with the repository owner may happen in Ukrainian, but committed documentation should be English unless explicitly requested otherwise.
+
+## Style
+
+Write documentation for a developer who opens the repository for the first time.
+
+Prefer concise but useful explanations.
+
+Avoid marketing language.
+
+Avoid vague claims like "enterprise-grade", "production-ready", or "highly scalable" unless the repository contains concrete implementation evidence.
+
+It is acceptable and useful to say that this is a pet project / playground.
+
+## Factuality
+
+Documentation must be based on the current repository structure and code.
+
+Do not describe planned functionality as existing functionality.
+
+If one implementation has a deployment path and another does not, state that clearly.
+
+If a setup step depends on local secrets, certificates, or credentials, use placeholders instead of real-looking values.
+
+## README structure
+
+For root README files, include:
+
+- project purpose;
+- repository layout;
+- available implementations;
+- technology highlights;
+- local development pointers;
+- CI/testing overview;
+- deployment overview;
+- links to implementation-specific README files.
+
+For implementation README files, include:
+
+- purpose of this implementation;
+- solution layout;
+- architecture overview;
+- runtime dependencies;
+- configuration;
+- local setup;
+- testing;
+- CI;
+- deployment notes, if applicable.
+
+## Links
+
+Prefer relative links inside the repository.
+
+Examples:
+
+```md
+[Monolith](apps/monolith/README.md)
+[Microservices](apps/mservices/README.md)
+```
+
+## Security
+
+Do not document real secrets, real passwords, real tokens, or real credentials.
+
+When commands require sensitive values, use placeholders:
+
+```bash
+dotnet dev-certs https -ep cert.pfx -p <local-dev-certificate-password>
+```

--- a/.ai/skills/monolith.md
+++ b/.ai/skills/monolith.md
@@ -1,0 +1,145 @@
+# Monolith skill
+
+Use this skill when working under `apps/monolith`.
+
+## Overview
+
+`apps/monolith` contains the modular monolith implementation of Contoso University.
+
+The main solution is:
+
+```text
+apps/monolith/ContosoUniversity.sln
+```
+
+The main executable application is:
+
+```text
+apps/monolith/src/ContosoUniversity.Mvc
+```
+
+## Architecture
+
+The monolith is a single deployable ASP.NET Core MVC application.
+
+It is internally split into:
+
+- `ContosoUniversity.Mvc` — MVC web application.
+- `ContosoUniversity.Application` — application contracts, commands, queries, validation behavior.
+- `ContosoUniversity.Domain` — domain entities and behavior.
+- `ContosoUniversity.Data` — shared EF Core / SQL Server infrastructure.
+- `ContosoUniversity.Data.Courses.Reads`
+- `ContosoUniversity.Data.Courses.Writes`
+- `ContosoUniversity.Data.Departments.Reads`
+- `ContosoUniversity.Data.Departments.Writes`
+- `ContosoUniversity.Data.Students.Reads`
+- `ContosoUniversity.Data.Students.Writes`
+
+The MVC application registers the application and data modules in the same process.
+
+Do not describe this implementation as multiple runtime services.
+
+## Runtime
+
+The local Docker Compose setup includes:
+
+- `web`
+- `mssql`
+- `mssql-migrator`
+- `aspire-dashboard`
+
+The web container depends on:
+
+- healthy SQL Server;
+- successfully completed database migrator.
+
+The MVC application exposes:
+
+```text
+/health/readiness
+/health/liveness
+```
+
+## Data access
+
+The implementation uses SQL Server and EF Core.
+
+Read/write access is separated by named connection strings:
+
+```text
+Courses-RO
+Courses-RW
+Students-RO
+Students-RW
+Departments-RO
+Departments-RW
+```
+
+Common SQL Server connection settings are composed through `SqlConnectionStringBuilder`.
+
+## Observability
+
+The monolith contains OpenTelemetry and Serilog configuration.
+
+The local compose setup includes Aspire Dashboard as an OTLP endpoint.
+
+When changing health endpoints, telemetry, or logging, check:
+
+- `Program.cs`;
+- Docker Compose environment variables;
+- ECS deployment environment variables.
+
+## Deployment
+
+The monolith has an AWS ECS/Fargate QA deployment path.
+
+Relevant files:
+
+```text
+.github/workflows/deploy-mnlth-prepare-artifacts.yml
+.github/workflows/deploy-mnlth-qa-aws-ecs-run.yml
+.github/workflows/deploy-mnlth-qa-aws-ecs-stop.yml
+apps/monolith/iac/envs/qa-aws-ecs
+apps/monolith/iac/modules/networking
+```
+
+The deployment uses Docker images published to GitHub Container Registry:
+
+```text
+ghcr.io/alexbohomol/cuweb
+ghcr.io/alexbohomol/mssql-migrator
+```
+
+The SQL Server deployment is container-based and runs in ECS/Fargate. Do not describe it as RDS.
+
+## Local setup
+
+Typical local startup:
+
+```bash
+cd apps/monolith
+docker compose up --build --wait
+```
+
+The MVC application is mapped to:
+
+```text
+http://localhost:10000
+https://localhost:10001
+```
+
+SQL Server is mapped to:
+
+```text
+localhost,1477
+```
+
+## Testing
+
+The solution contains unit, integration, e2e, and system tests.
+
+Prefer:
+
+- domain behavior -> unit tests;
+- MVC/database integration -> integration tests;
+- browser/user workflows -> e2e tests.

--- a/.ai/skills/monolith.md
+++ b/.ai/skills/monolith.md
@@ -116,8 +116,8 @@ The SQL Server deployment is container-based and runs in ECS/Fargate. Do not des
 
 Typical local startup:
 
+Navigate to `apps/monolith` folder and run
 ```bash
-cd apps/monolith
 docker compose up --build --wait
 ```
 

--- a/.ai/skills/mservices.md
+++ b/.ai/skills/mservices.md
@@ -1,0 +1,140 @@
+# Microservices skill
+
+Use this skill when working under `apps/mservices`.
+
+## Overview
+
+`apps/mservices` contains the microservices-style implementation of Contoso University.
+
+The main solution is:
+
+```text
+apps/mservices/ContosoUniversity.sln
+```
+
+This implementation keeps an MVC frontend but moves backend responsibilities into separate APIs and workers.
+
+## Runtime services
+
+The local runtime contains:
+
+- `web`
+- `courses-api`
+- `courses-worker`
+- `departments-api`
+- `departments-worker`
+- `students-api`
+- `students-worker`
+- `mssql`
+- `mssql-migrator`
+- `rabbitmq`
+
+## Frontend boundary
+
+`ContosoUniversity.Mvc` is the frontend.
+
+It should communicate with backend services through typed HTTP clients from:
+
+```text
+ContosoUniversity.ApiClients
+```
+
+The MVC frontend should not directly depend on EF Core data modules.
+
+Do not add direct database access to the MVC frontend unless the architectural decision is explicitly changed.
+
+## APIs
+
+Backend APIs are implemented as Minimal APIs:
+
+```text
+Courses.Api
+Departments.Api
+Students.Api
+```
+
+Read operations usually use read repositories.
+
+Write operations usually go through MediatR commands.
+
+## Workers
+
+Background workers consume RabbitMQ/MassTransit events:
+
+```text
+Courses.Worker
+Departments.Worker
+Students.Worker
+```
+
+Workers are responsible for asynchronous cross-domain cleanup workflows.
+
+## Messaging
+
+Messaging contracts live in:
+
+```text
+ContosoUniversity.Messaging.Contracts
+```
+
+Current events include:
+
+```text
+course-deleted-event
+department-deleted-event
+```
+
+Current flow:
+
+```text
+Delete Department
+  -> DepartmentDeletedEvent
+  -> Courses.Worker removes related courses
+  -> course deletion publishes CourseDeletedEvent
+  -> Students.Worker withdraws enrolled students
+  -> Departments.Worker resets instructor course assignments
+```
+
+When adding new cross-domain behavior, consider whether it belongs in:
+
+- synchronous API composition;
+- asynchronous event publication;
+- worker consumer;
+- shared contract.
+
+## Docker Compose
+
+The local Docker Compose environment is the canonical local runtime.
+
+Typical startup:
+
+```bash
+cd apps/mservices
+docker compose up --build --wait
+```
+
+The MVC frontend uses service DNS names in Docker Compose:
+
+```text
+http://courses-api
+http://departments-api
+http://students-api
+```
+
+## Deployment
+
+Do not claim that this implementation has the same AWS ECS/Fargate deployment path as the monolith.
+
+As of the current repository state, the microservices implementation has local Docker Compose runtime and CI validation, but no dedicated cloud deployment workflow or Terraform environment equivalent to `apps/monolith/iac/envs/qa-aws-ecs`.
+
+## Testing
+
+Integration tests exist for:
+
+- MVC frontend;
+- APIs;
+- workers.
+
+Use RabbitMQ and SQL Server test infrastructure where needed.
+
+Use WireMock or equivalent HTTP boundary testing when testing HTTP clients or service-to-service calls.

--- a/.ai/skills/mservices.md
+++ b/.ai/skills/mservices.md
@@ -108,8 +108,8 @@ The local Docker Compose environment is the canonical local runtime.
 
 Typical startup:
 
+Navigate to `apps/mservices` folder and run
 ```bash
-cd apps/mservices
 docker compose up --build --wait
 ```
 

--- a/.ai/skills/testing.md
+++ b/.ai/skills/testing.md
@@ -1,0 +1,101 @@
+# Testing skill
+
+Use this skill when adding, changing, or reviewing tests.
+
+## General principles
+
+Choose the test level based on where the behavior lives.
+
+Do not replace meaningful integration tests with unit tests when the behavior depends on ASP.NET Core hosting, EF Core, SQL Server, RabbitMQ, HTTP clients, or Docker runtime wiring.
+
+Do not add broad end-to-end tests for behavior that can be covered reliably at the domain, API, or worker level.
+
+## Test levels
+
+### Unit tests
+
+Use unit tests for:
+
+- domain behavior;
+- value objects;
+- pure application logic;
+- validation rules;
+- command/query handler logic when dependencies can be isolated safely.
+
+### Integration tests
+
+Use integration tests for:
+
+- ASP.NET Core endpoints;
+- EF Core repositories;
+- SQL Server behavior;
+- RabbitMQ consumers;
+- typed HTTP clients;
+- worker handlers;
+- service wiring.
+
+### E2E / acceptance tests
+
+Use e2e tests for:
+
+- browser-visible user workflows;
+- MVC page navigation;
+- form submissions;
+- high-level smoke scenarios.
+
+## Existing tooling
+
+The repository uses several testing tools depending on the implementation and test level:
+
+- xUnit
+- NUnit
+- SpecFlow
+- Playwright
+- Testcontainers.MsSql
+- Testcontainers.RabbitMq
+- WireMock.Net
+- Ductus.FluentDocker
+- Microsoft.AspNetCore.Mvc.Testing
+
+## Monolith testing
+
+`apps/monolith` contains:
+
+- unit tests;
+- integration tests;
+- e2e tests;
+- system tests.
+
+Integration tests cover the MVC application and database-dependent behavior.
+
+Acceptance tests use Playwright, NUnit, SpecFlow, and Docker-based infrastructure.
+
+## Microservices testing
+
+`apps/mservices` contains tests for:
+
+- MVC frontend;
+- Courses API;
+- Departments API;
+- Students API;
+- Courses worker;
+- Departments worker;
+- Students worker.
+
+When changing a worker consumer, add or update worker integration tests.
+
+When changing an API endpoint, add or update API integration tests.
+
+When changing typed HTTP clients, consider WireMock-based tests.
+
+## CI expectations
+
+Before considering a change complete, the relevant solution should be able to run:
+
+```bash
+dotnet restore
+dotnet build --no-restore
+dotnet test --no-build
+```
+
+If a change affects formatting or analyzers, expect `dotnet format` checks to run in CI.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,52 @@
+# Copilot instructions for Contoso University
+
+This repository is a pet project named **Contoso University**. It is based on the canonical ASP.NET / Entity Framework demo application and has been evolved into a modern .NET playground for practicing architecture, testing, infrastructure, CI/CD, observability, and deployment concepts.
+
+The repository contains two functionally similar implementations of the same university domain:
+
+- `apps/monolith` — ASP.NET Core MVC modular monolith.
+- `apps/mservices` — microservices-style implementation with MVC frontend, APIs, workers, HTTP clients, RabbitMQ, and Docker Compose.
+
+## General rules
+
+Always inspect the actual repository code before making claims about architecture, behavior, dependencies, or deployment.
+
+Do not infer implementation details from general ASP.NET Core, EF Core, Docker, or microservices conventions when the repository can be checked.
+
+Prefer small, focused changes that preserve the existing structure, naming style, and architectural boundaries.
+
+Documentation must be written in English.
+
+When modifying code, update or add tests at the appropriate level.
+
+When answering architecture questions, distinguish between:
+
+- .NET projects;
+- runtime services;
+- deployable units;
+- domain modules;
+- data access modules;
+- test-only infrastructure.
+
+## Important repository boundaries
+
+For `apps/monolith`:
+
+- The MVC application is the main deployable unit.
+- The MVC application may directly register and use application/data modules.
+- The monolith has an AWS ECS/Fargate QA deployment path.
+
+For `apps/mservices`:
+
+- `ContosoUniversity.Mvc` is a frontend and should communicate with backend services through typed HTTP clients.
+- The MVC frontend should not directly depend on EF Core data modules.
+- Cross-domain cleanup workflows use RabbitMQ/MassTransit events and background workers.
+- A dedicated cloud deployment path is not currently implemented in the same way as the monolith ECS setup.
+
+## Style
+
+Keep explanations practical and repository-specific.
+
+Avoid enterprise buzzwords unless they describe the actual implementation.
+
+If the code is missing, inconclusive, or inconsistent, say so explicitly.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,82 @@
-### Contoso University
+# Contoso University
 
-![.NET Core](https://github.com/alexbogomol/ContosoUniversity.Core/workflows/.NET%20Core/badge.svg)
+Contoso University is a pet project based on the canonical ASP.NET / Entity Framework demo application. The original sample has been evolved into a modern .NET codebase that is useful for experimenting with application architecture, data access patterns, integration testing, observability, containerization, CI, and deployment automation in a deliberately small domain.
 
-Walkthrough the canonical [tutorial](https://docs.microsoft.com/en-us/aspnet/mvc/overview/getting-started/getting-started-with-ef-using-mvc) updated to .Net Core version is [here](https://docs.microsoft.com/uk-ua/aspnet/core/data/ef-mvc).
+The repository contains two functionally similar implementations of the same university information system:
 
-.Net Core implementation imported from [cu-final](https://github.com/aspnet/AspNetCore.Docs/tree/master/aspnetcore/data/ef-mvc/intro/samples/cu-final).
+- [Monolith](apps/monolith/README.md) — an ASP.NET Core MVC modular monolith.
+- [Microservices](apps/mservices/README.md) — a microservices-style implementation with separate APIs, background workers, HTTP clients, and RabbitMQ messaging.
+
+Both implementations model the same broad Contoso University domain: courses, departments, instructors, students, enrollments, and related administrative workflows. The purpose of the repository is not to provide a production-ready university system, but to keep a compact playground where architectural and infrastructure ideas can be tested without the weight of a real enterprise application.
+
+## Repository layout
+
+```text
+.
+├── apps
+│   ├── monolith      # Modular monolith implementation
+│   └── mservices     # Microservices-style implementation
+├── database          # SQL Server initialization / migration scripts
+├── definitions.json  # RabbitMQ definitions used by the microservices setup
+└── rabbitmq.conf     # RabbitMQ configuration used by the microservices setup
+```
+
+## Implementations
+
+### Monolith
+
+The monolith is a single deployable ASP.NET Core MVC application split internally into application, domain, data, and read/write data-access modules. It uses SQL Server, EF Core, MediatR, FluentValidation, OpenTelemetry, Serilog, Docker Compose, and GitHub Actions. It also contains infrastructure-as-code for deploying a QA environment to AWS ECS/Fargate.
+
+Read more: [apps/monolith/README.md](apps/monolith/README.md)
+
+### Microservices
+
+The microservices implementation keeps the MVC frontend but moves backend responsibilities into separate services: `Courses.Api`, `Departments.Api`, `Students.Api`, and matching workers for asynchronous cross-domain consistency. Services communicate through HTTP and RabbitMQ events via MassTransit. The local environment is orchestrated with Docker Compose and includes SQL Server, RabbitMQ, APIs, workers, and the MVC frontend.
+
+Read more: [apps/mservices/README.md](apps/mservices/README.md)
+
+## Technology highlights
+
+The repository currently uses:
+
+- .NET 10 target framework across the application solutions.
+- ASP.NET Core MVC and Minimal APIs.
+- Entity Framework Core with SQL Server.
+- MediatR and FluentValidation for application workflows and validation.
+- Docker Compose for local multi-container environments.
+- RabbitMQ and MassTransit in the microservices implementation.
+- OpenTelemetry and Serilog in the monolith implementation.
+- GitHub Actions for build, style, unit, integration, and deployment workflows.
+- Terraform for the monolith AWS ECS/Fargate QA environment.
+
+## Local development
+
+Each implementation has its own solution, Docker Compose setup, and README:
+
+- [Monolith local setup](apps/monolith/README.md#local-setup)
+- [Microservices local setup](apps/mservices/README.md#local-setup)
+
+At a high level, the expected prerequisites are:
+
+- .NET SDK compatible with the repository target framework.
+- Docker with Docker Compose support.
+- A developer HTTPS certificate when running the MVC application in containers.
+
+## CI and quality gates
+
+The repository contains separate GitHub Actions workflows for the two implementations:
+
+- Monolith PR checks build the solution, run unit tests, validate formatting/style/analyzers, and run integration tests.
+- Microservices PR checks build the solution, run unit tests, validate formatting/style/analyzers, and run integration tests for the MVC frontend, APIs, and workers.
+
+Warnings and code analysis are treated strictly in the solution-level build configuration.
+
+## Deployment
+
+The monolith contains an AWS ECS/Fargate QA deployment path with Docker images published to GitHub Container Registry and infrastructure defined in Terraform. See [Monolith deployment](apps/monolith/README.md#deployment).
+
+The microservices implementation currently has a complete Docker Compose local runtime and CI checks. A cloud deployment path is not described in the repository in the same way as the monolith ECS setup. See [Microservices deployment notes](apps/mservices/README.md#deployment-notes).
+
+## Origin
+
+The starting point for this project is the canonical Contoso University tutorial application. This repository continues that idea as a modernized, experimental .NET playground rather than a direct tutorial copy.

--- a/apps/monolith/README.md
+++ b/apps/monolith/README.md
@@ -12,6 +12,7 @@ apps/monolith
 ├── docker-compose.yml
 ├── docker-compose.override.yml
 ├── iac
+│   ├── bootstrap
 │   ├── envs
 │   │   ├── qa-aws-ebt
 │   │   └── qa-aws-ecs

--- a/apps/monolith/README.md
+++ b/apps/monolith/README.md
@@ -16,7 +16,10 @@ apps/monolith
 │   ├── envs
 │   │   ├── qa-aws-ebt
 │   │   └── qa-aws-ecs
-│   └── modules/networking
+│   └── modules
+│       ├── beanstalk
+│       ├── networking
+│       └── rds--mssql
 ├── src
 │   ├── ContosoUniversity.Mvc
 │   ├── ContosoUniversity.Application

--- a/apps/monolith/README.md
+++ b/apps/monolith/README.md
@@ -19,7 +19,7 @@ apps/monolith
 │   └── modules
 │       ├── beanstalk
 │       ├── networking
-│       └── rds--mssql
+│       └── rds-mssql
 ├── src
 │   ├── ContosoUniversity.Mvc
 │   ├── ContosoUniversity.Application
@@ -37,6 +37,8 @@ apps/monolith
     ├── e2e
     └── system
 ```
+> [!IMPORTANT]
+> This diagram should be updated in case any changes in directory structure take place
 
 ## Architecture overview
 

--- a/apps/monolith/README.md
+++ b/apps/monolith/README.md
@@ -1,0 +1,231 @@
+# Contoso University — Monolith
+
+This directory contains the modular monolith implementation of Contoso University.
+
+It is a single deployable ASP.NET Core MVC application, but the code is split into application, domain, data infrastructure, and feature-oriented read/write data-access projects. The implementation is useful for practicing modular monolith design, EF Core data access, validation, MediatR-based application workflows, integration testing, observability, Docker-based local environments, and AWS ECS/Fargate deployment automation.
+
+## Solution layout
+
+```text
+apps/monolith
+├── ContosoUniversity.sln
+├── docker-compose.yml
+├── docker-compose.override.yml
+├── iac
+│   ├── envs/qa-aws-ecs
+│   └── modules/networking
+├── src
+│   ├── ContosoUniversity.Mvc
+│   ├── ContosoUniversity.Application
+│   ├── ContosoUniversity.Domain
+│   ├── ContosoUniversity.Data
+│   ├── ContosoUniversity.Data.Courses.Reads
+│   ├── ContosoUniversity.Data.Courses.Writes
+│   ├── ContosoUniversity.Data.Departments.Reads
+│   ├── ContosoUniversity.Data.Departments.Writes
+│   ├── ContosoUniversity.Data.Students.Reads
+│   └── ContosoUniversity.Data.Students.Writes
+└── test
+    ├── unit
+    ├── integration
+    ├── e2e
+    └── system
+```
+
+## Architecture overview
+
+The monolith has one web entry point: `ContosoUniversity.Mvc`.
+
+Internally, the solution is organized into several layers:
+
+- `ContosoUniversity.Mvc` — ASP.NET Core MVC application with controllers, views, view models, filters, exception handling, health endpoints, and Docker packaging.
+- `ContosoUniversity.Application` — application-level contracts, commands, queries, MediatR handlers, and validation behavior.
+- `ContosoUniversity.Domain` — domain entities and domain behavior for courses, departments, instructors, students, enrollments, and related concepts.
+- `ContosoUniversity.Data` — shared EF Core / SQL Server infrastructure and connection string composition.
+- `ContosoUniversity.Data.*.Reads` — read-side data access modules.
+- `ContosoUniversity.Data.*.Writes` — write-side data access modules.
+
+The MVC application registers all data modules in the same process. Controllers use MediatR commands/queries and repositories to execute application workflows.
+
+## Runtime dependencies
+
+The local Docker Compose environment contains:
+
+- `web` — the MVC application.
+- `mssql` — SQL Server container.
+- `mssql-migrator` — database initialization / migration container built from the repository `database` directory.
+- `aspire-dashboard` — .NET Aspire dashboard used as an OTLP endpoint in the local compose setup.
+
+The web container depends on a healthy SQL Server container and a successfully completed migrator container before starting.
+
+## Configuration
+
+The MVC application uses named connection strings for read/write access by domain area:
+
+```text
+Courses-RO
+Courses-RW
+Students-RO
+Students-RW
+Departments-RO
+Departments-RW
+```
+
+Common SQL Server options are composed through the `SqlConnectionStringBuilder` configuration section. In Docker Compose, `SqlConnectionStringBuilder__DataSource` is overridden to point to the `mssql` service.
+
+The application exposes health endpoints:
+
+```text
+/health/readiness
+/health/liveness
+```
+
+## Local setup
+
+### Prerequisites
+
+- .NET SDK compatible with the solution target framework.
+- Docker with Docker Compose support.
+- Local developer HTTPS certificate tooling if HTTPS container access is needed.
+
+### Prepare a development certificate
+
+The Dockerfile expects a certificate file at:
+
+```text
+apps/monolith/src/ContosoUniversity.Mvc/cert.pfx
+```
+
+Generate it with `dotnet dev-certs` from the MVC project directory. Use the same certificate password as the one configured for the local Docker Compose environment, or change the compose environment variable accordingly.
+
+```bash
+cd apps/monolith/src/ContosoUniversity.Mvc
+dotnet dev-certs https -ep cert.pfx -p <local-dev-certificate-password>
+```
+
+### Start the local environment
+
+From `apps/monolith`:
+
+```bash
+docker compose up --build --wait
+```
+
+The compose override maps the MVC application to:
+
+```text
+http://localhost:10000
+https://localhost:10001
+```
+
+SQL Server is exposed on the host as:
+
+```text
+localhost,1477
+```
+
+### Stop the local environment
+
+```bash
+docker compose down
+```
+
+To remove volumes as well:
+
+```bash
+docker compose down -v
+```
+
+## Running tests
+
+From `apps/monolith`:
+
+```bash
+dotnet restore
+dotnet build --no-restore
+dotnet test --no-build
+```
+
+The solution contains unit, integration, e2e, and system test projects. Integration tests use ASP.NET Core test infrastructure and SQL Server test containers. Acceptance tests use Playwright, NUnit, SpecFlow, and Docker-based infrastructure.
+
+## CI
+
+The monolith PR-check workflow builds the solution, runs unit tests, validates whitespace/style/analyzer formatting with `dotnet format`, and runs integration tests.
+
+The workflow is scoped to changes under:
+
+```text
+apps/monolith/**
+database/**
+.github/**
+```
+
+## Deployment
+
+The monolith includes an AWS ECS/Fargate QA deployment path.
+
+### Artifact workflow
+
+The GitHub Actions workflow `MNLTH / Deploy / Artifacts` builds and pushes Docker images to GitHub Container Registry:
+
+```text
+ghcr.io/alexbohomol/cuweb
+ghcr.io/alexbohomol/mssql-migrator
+```
+
+Images are tagged with a short Git commit SHA. The default branch also receives the `latest` tag.
+
+### Infrastructure
+
+Terraform configuration for the QA environment is located under:
+
+```text
+apps/monolith/iac/envs/qa-aws-ecs
+```
+
+It defines:
+
+- VPC and public subnets through the `networking` module.
+- ECS cluster.
+- ECS/Fargate task definitions for `web`, `mssql`, and `mssql-migrator`.
+- ECS services for the web application and SQL Server container.
+- CloudWatch log groups.
+- EFS storage for ASP.NET Core Data Protection keys.
+- Cloud Map service discovery for SQL Server.
+- Application Load Balancer.
+- HTTP and HTTPS listeners.
+- HTTP-to-HTTPS redirect.
+- Route 53 alias record for the configured domain.
+
+The default domain configured in Terraform is:
+
+```text
+qa-aws-ecs.mnlth.university.contoso.name
+```
+
+### Run workflow
+
+The workflow `MNLTH / qa-aws-ecs / Run` is manually triggered and can:
+
+- resolve the image tag to deploy;
+- start the SQL Server ECS service;
+- run the database migrator as a one-off ECS task;
+- start or update the web ECS service;
+- scale the web service through the `web_desired_count` input.
+
+It also supports an `update_web_only` mode for updating only the web service.
+
+### Stop workflow
+
+The workflow `MNLTH / qa-aws-ecs / Stop` is manually triggered and scales down:
+
+```text
+contoso-mnlth-web-service   -> desired-count 0
+contoso-mnlth-mssql-service -> desired-count 0
+```
+
+This makes the QA environment suitable for temporary use and cost control.
+
+## Notes
+
+The SQL Server deployment in this archetype is intentionally container-based and runs in ECS/Fargate. It is useful for experimentation and short-lived environments, but it should not be confused with a managed database service such as Amazon RDS.

--- a/apps/monolith/README.md
+++ b/apps/monolith/README.md
@@ -12,7 +12,9 @@ apps/monolith
 ├── docker-compose.yml
 ├── docker-compose.override.yml
 ├── iac
-│   ├── envs/qa-aws-ecs
+│   ├── envs
+│   │   ├── qa-aws-ebt
+│   │   └── qa-aws-ecs
 │   └── modules/networking
 ├── src
 │   ├── ContosoUniversity.Mvc
@@ -100,7 +102,9 @@ Generate it with `dotnet dev-certs` from the MVC project directory. Use the same
 
 ```bash
 cd apps/monolith/src/ContosoUniversity.Mvc
-dotnet dev-certs https -ep cert.pfx -p <local-dev-certificate-password>
+```
+```bash
+dotnet dev-certs https -ep cert.pfx -p Test1234!
 ```
 
 ### Start the local environment

--- a/apps/mservices/README.md
+++ b/apps/mservices/README.md
@@ -41,6 +41,8 @@ apps/mservices
     ├── e2e
     └── system
 ```
+> [!IMPORTANT]
+> This diagram should be updated in case any changes in directory structure take place
 
 ## Architecture overview
 

--- a/apps/mservices/README.md
+++ b/apps/mservices/README.md
@@ -200,7 +200,9 @@ Generate it with `dotnet dev-certs` from the MVC project directory. Use the same
 
 ```bash
 cd apps/mservices/src/ContosoUniversity.Mvc
-dotnet dev-certs https -ep cert.pfx -p <local-dev-certificate-password>
+```
+```bash
+dotnet dev-certs https -ep cert.pfx -p Test1234!
 ```
 
 ### Start the local environment
@@ -214,7 +216,7 @@ docker compose up --build --wait
 The compose override maps the main services to the host:
 
 ```text
-web                  http://localhost:10000, https://localhost:10001
+web                   http://localhost:10000, https://localhost:10001
 courses-api           http://localhost:5006
 departments-api       http://localhost:5079
 students-api          http://localhost:5110

--- a/apps/mservices/README.md
+++ b/apps/mservices/README.md
@@ -1,0 +1,280 @@
+# Contoso University — Microservices
+
+This directory contains the microservices-style implementation of Contoso University.
+
+It keeps the same broad university domain as the monolith, but splits the backend into separate API services and background workers. The MVC frontend communicates with backend services through typed HTTP clients, while cross-domain cleanup workflows are coordinated asynchronously with RabbitMQ and MassTransit.
+
+This implementation is useful for practicing service boundaries, HTTP service-to-service communication, event-driven consistency, background workers, integration testing with external dependencies, and Docker Compose orchestration.
+
+## Solution layout
+
+```text
+apps/mservices
+├── ContosoUniversity.sln
+├── docker-compose.yml
+├── docker-compose.override.yml
+├── src
+│   ├── ContosoUniversity.Mvc
+│   ├── ContosoUniversity.Application
+│   ├── ContosoUniversity.ApiClients
+│   ├── ContosoUniversity.Data
+│   ├── ContosoUniversity.Messaging.Contracts
+│   ├── ContosoUniversity.SharedKernel
+│   ├── Courses.Api
+│   ├── Courses.Core
+│   ├── Courses.Data.Reads
+│   ├── Courses.Data.Writes
+│   ├── Courses.Worker
+│   ├── Departments.Api
+│   ├── Departments.Core
+│   ├── Departments.Data.Reads
+│   ├── Departments.Data.Writes
+│   ├── Departments.Worker
+│   ├── Students.Api
+│   ├── Students.Core
+│   ├── Students.Data.Reads
+│   ├── Students.Data.Writes
+│   └── Students.Worker
+└── test
+    ├── unit
+    ├── integration
+    ├── e2e
+    └── system
+```
+
+## Architecture overview
+
+The implementation consists of several runtime services:
+
+- `ContosoUniversity.Mvc` — ASP.NET Core MVC frontend.
+- `Courses.Api` — Minimal API for course read/write operations.
+- `Departments.Api` — Minimal API for departments and instructors.
+- `Students.Api` — Minimal API for student read/write operations.
+- `Courses.Worker` — background consumer for department deletion events.
+- `Departments.Worker` — background consumer for course deletion events affecting instructor assignments.
+- `Students.Worker` — background consumer for course deletion events affecting student enrollments.
+
+The shared projects provide infrastructure and contracts:
+
+- `ContosoUniversity.ApiClients` — typed HTTP clients used by the MVC frontend.
+- `ContosoUniversity.Messaging.Contracts` — RabbitMQ/MassTransit event contracts.
+- `ContosoUniversity.Data` — shared EF Core / SQL Server infrastructure.
+- `ContosoUniversity.SharedKernel` — shared domain building blocks.
+- `*.Core` projects — domain and application behavior for each service area.
+- `*.Data.Reads` and `*.Data.Writes` projects — read/write data access modules.
+
+## Communication model
+
+### Synchronous HTTP
+
+The MVC frontend does not access the database directly. It registers typed HTTP clients and calls the backend APIs:
+
+```text
+ContosoUniversity.Mvc
+  -> Courses.Api
+  -> Departments.Api
+  -> Students.Api
+```
+
+In Docker Compose, the frontend uses service DNS names:
+
+```text
+http://courses-api
+http://departments-api
+http://students-api
+```
+
+### Asynchronous messaging
+
+RabbitMQ is used for cross-domain cleanup workflows.
+
+Current events:
+
+```text
+course-deleted-event
+department-deleted-event
+```
+
+Current event flow:
+
+```text
+Delete Department
+  -> DepartmentDeletedEvent
+  -> Courses.Worker removes related courses
+  -> course deletion publishes CourseDeletedEvent
+  -> Students.Worker withdraws enrolled students
+  -> Departments.Worker resets instructor course assignments
+```
+
+This keeps cross-domain reactions out of the original HTTP request path and demonstrates eventual consistency in a small domain.
+
+## Runtime dependencies
+
+The local Docker Compose environment contains:
+
+- `web`
+- `courses-api`
+- `courses-worker`
+- `departments-api`
+- `departments-worker`
+- `students-api`
+- `students-worker`
+- `mssql`
+- `mssql-migrator`
+- `rabbitmq`
+
+RabbitMQ uses the repository-level `rabbitmq.conf` and `definitions.json` files.
+
+## API overview
+
+### Courses API
+
+Selected endpoints:
+
+```text
+GET    /api/courses
+GET    /api/courses/{externalId}
+GET    /api/courses/existsByCourseCode/{courseCode}
+GET    /api/courses/title
+POST   /api/courses
+PUT    /api/courses/{externalId}
+DELETE /api/courses/{externalId}
+PUT    /api/courses/credits/update
+```
+
+### Departments API
+
+Selected department endpoints:
+
+```text
+GET    /api/departments
+GET    /api/departments/names
+GET    /api/departments/{externalId}
+POST   /api/departments
+PUT    /api/departments/{externalId}
+DELETE /api/departments/{externalId}
+```
+
+Selected instructor endpoints:
+
+```text
+GET    /api/instructors
+GET    /api/instructors/names
+GET    /api/instructors/{externalId}
+POST   /api/instructors
+PUT    /api/instructors/{externalId}
+DELETE /api/instructors/{externalId}
+```
+
+### Students API
+
+Selected endpoints:
+
+```text
+GET    /api/students/{externalId}
+GET    /api/students/enrolled/groups
+GET    /api/students/enrolled
+POST   /api/students/search
+POST   /api/students
+PUT    /api/students/{externalId}
+DELETE /api/students/{externalId}
+```
+
+## Local setup
+
+### Prerequisites
+
+- .NET SDK compatible with the solution target framework.
+- Docker with Docker Compose support.
+- Local developer HTTPS certificate tooling if HTTPS container access is needed.
+
+### Prepare a development certificate
+
+The MVC Dockerfile expects a certificate file at:
+
+```text
+apps/mservices/src/ContosoUniversity.Mvc/cert.pfx
+```
+
+Generate it with `dotnet dev-certs` from the MVC project directory. Use the same certificate password as the one configured for the local Docker Compose environment, or change the compose environment variable accordingly.
+
+```bash
+cd apps/mservices/src/ContosoUniversity.Mvc
+dotnet dev-certs https -ep cert.pfx -p <local-dev-certificate-password>
+```
+
+### Start the local environment
+
+From `apps/mservices`:
+
+```bash
+docker compose up --build --wait
+```
+
+The compose override maps the main services to the host:
+
+```text
+web                  http://localhost:10000, https://localhost:10001
+courses-api           http://localhost:5006
+departments-api       http://localhost:5079
+students-api          http://localhost:5110
+courses-worker        http://localhost:5025
+departments-worker    http://localhost:5036
+students-worker       http://localhost:5037
+rabbitmq management   http://localhost:15672
+mssql                 localhost,1477
+```
+
+### Stop the local environment
+
+```bash
+docker compose down
+```
+
+To remove volumes as well:
+
+```bash
+docker compose down -v
+```
+
+## Running tests
+
+From `apps/mservices`:
+
+```bash
+dotnet restore
+dotnet build --no-restore
+dotnet test --no-build
+```
+
+The solution contains unit, integration, e2e, and system test projects. Integration coverage includes the MVC frontend, APIs, and workers. The test dependencies include SQL Server and RabbitMQ test containers, plus WireMock for HTTP boundary testing where needed.
+
+## CI
+
+The microservices PR-check workflow builds the solution, runs unit tests, validates whitespace/style/analyzer formatting with `dotnet format`, and runs integration tests for:
+
+- `ContosoUniversity.Mvc`
+- `Courses.Api`
+- `Courses.Worker`
+- `Departments.Api`
+- `Departments.Worker`
+- `Students.Api`
+- `Students.Worker`
+
+The workflow is scoped to changes under:
+
+```text
+apps/mservices/**
+database/**
+.github/**
+```
+
+## Deployment notes
+
+This implementation currently has a complete Docker Compose runtime for local development and CI-level validation workflows.
+
+Unlike the monolith implementation, this directory does not currently include a dedicated cloud deployment path such as Terraform infrastructure or GitHub Actions deployment workflows for ECS/Fargate. If such a deployment is added later, this README should be extended with environment topology, image publishing, infrastructure provisioning, service discovery, RabbitMQ hosting, database strategy, and rollout instructions.
+
+## Notes
+
+The microservices implementation intentionally keeps the domain small while introducing additional operational concerns: service boundaries, multiple runtime processes, broker-based messaging, event handlers, and consistency workflows that would be unnecessary in the monolith version but useful for architectural practice.


### PR DESCRIPTION
## Summary

Adds documentation for the repository, both application archetypes, and AI-assistant guidance:

- updates the root `README.md` with a repository overview, purpose, architecture variants, technology highlights, CI notes, and links to implementation-specific READMEs;
- adds `apps/monolith/README.md` with architecture, local setup, testing, CI, and AWS ECS/Fargate deployment notes;
- adds `apps/mservices/README.md` with architecture, local setup, API overview, messaging flow, testing, CI, and deployment notes;
- adds `.github/copilot-instructions.md` with repository-level Copilot guidance;
- adds `.ai/README.md` and skill files for code analysis, documentation, monolith, microservices, testing, Docker Compose, GitHub Actions, and AWS ECS deployment.

## Notes

The documentation is based on the current repository structure and implementation files. The microservices README and skill files explicitly state that a dedicated cloud deployment path is not currently present in the repository in the same way as the monolith ECS setup.

The AI guidance emphasizes repository-first analysis: agents should inspect the actual code before making architecture, behavior, deployment, or testing claims.

## Testing

Documentation-only change; no code changes.