### PR TITLE
CONTOSO: Upgrade versions for used GHAs

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -29,11 +29,11 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Setup .NET
       if: ${{ matrix.language }} == 'csharp'
-      uses: actions/setup-dotnet@v4
+      uses: actions/setup-dotnet@v5
       with:
         dotnet-version: ${{ env.DOTNET_VERSION }}
 

--- a/.github/workflows/deploy-mnlth-prepare-artifacts.yml
+++ b/.github/workflows/deploy-mnlth-prepare-artifacts.yml
@@ -15,17 +15,17 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Extract short SHA
         id: extract-sha
         run: echo "SHORT_SHA=$(git rev-parse --short ${{ github.event.pull_request.head.sha || github.sha }})" >> $GITHUB_OUTPUT
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -39,7 +39,7 @@ jobs:
 
       - name: Docker metadata
         id: metadata
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ghcr.io/alexbohomol/cuweb
           tags: |
@@ -49,7 +49,7 @@ jobs:
             type=raw,value=latest,enable={{is_default_branch}}
 
       - name: Build and push cuweb image
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v7
         with:
           context: ${{ vars.MONOLITH_SLN_PATH }}
           file: ${{ vars.MONOLITH_SLN_PATH }}/src/ContosoUniversity.Mvc/Dockerfile
@@ -62,17 +62,17 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Extract short SHA
         id: extract-sha
         run: echo "SHORT_SHA=$(git rev-parse --short ${{ github.event.pull_request.head.sha || github.sha }})" >> $GITHUB_OUTPUT
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -80,7 +80,7 @@ jobs:
 
       - name: Docker metadata
         id: metadata
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ghcr.io/alexbohomol/mssql-migrator
           tags: |
@@ -90,7 +90,7 @@ jobs:
             type=raw,value=latest,enable={{is_default_branch}}
 
       - name: Build and push mssql-migrator image
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v7
         with:
           context: database
           push: true

--- a/.github/workflows/deploy-mnlth-qa-aws-ecs-dispose.yml
+++ b/.github/workflows/deploy-mnlth-qa-aws-ecs-dispose.yml
@@ -17,17 +17,17 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: eu-central-1
 
       - name: Terraform install
-        uses: hashicorp/setup-terraform@v3
+        uses: hashicorp/setup-terraform@v4
         with:
           terraform_version: ${{ env.TF_VERSION }}
 

--- a/.github/workflows/deploy-mnlth-qa-aws-ecs-provision.yml
+++ b/.github/workflows/deploy-mnlth-qa-aws-ecs-provision.yml
@@ -19,17 +19,17 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: eu-central-1
 
       - name: Terraform install
-        uses: hashicorp/setup-terraform@v3
+        uses: hashicorp/setup-terraform@v4
         with:
           terraform_version: ${{ env.TF_VERSION }}
 

--- a/.github/workflows/deploy-mnlth-qa-aws-ecs-run.yml
+++ b/.github/workflows/deploy-mnlth-qa-aws-ecs-run.yml
@@ -27,7 +27,7 @@ jobs:
 
     steps:
       - name: 🛠️ Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: 🎖️ Resolve image tag
         id: resolve-image-tag
@@ -49,10 +49,10 @@ jobs:
 
     steps:
       - name: 🛠️ Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: 🔐 Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -86,10 +86,10 @@ jobs:
 
     steps:
       - name: 🛠️ Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: 🔐 Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -128,10 +128,10 @@ jobs:
 
     steps:
       - name: 🛠️ Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: 🔐 Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/deploy-mnlth-qa-aws-ecs-stop.yml
+++ b/.github/workflows/deploy-mnlth-qa-aws-ecs-stop.yml
@@ -11,10 +11,10 @@ jobs:
 
     steps:
       - name: 🛠️ Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: 🔐 Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -43,10 +43,10 @@ jobs:
 
     steps:
       - name: 🛠️ Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: 🔐 Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/pr-mnlth-fast.yml
+++ b/.github/workflows/pr-mnlth-fast.yml
@@ -22,10 +22,10 @@ jobs:
         working-directory: ${{ vars.MONOLITH_SLN_PATH }}
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       
     - name: Setup .NET
-      uses: actions/setup-dotnet@v4
+      uses: actions/setup-dotnet@v5
       with:
         dotnet-version: ${{ env.DOTNET_VERSION }}
         
@@ -46,10 +46,10 @@ jobs:
         working-directory: ${{ vars.MONOLITH_SLN_PATH }}
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       
     - name: Setup .NET
-      uses: actions/setup-dotnet@v4
+      uses: actions/setup-dotnet@v5
       with:
         dotnet-version: ${{ env.DOTNET_VERSION }}
         
@@ -87,7 +87,7 @@ jobs:
       TEST_PROJ_PATH: ${{ vars.MONOLITH_SLN_PATH }}/test/integration/ContosoUniversity.Mvc.IntegrationTests
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Developer Cert
       working-directory: ${{ vars.MONOLITH_SLN_PATH }}/src/ContosoUniversity.Mvc
@@ -101,7 +101,7 @@ jobs:
         docker pull mcr.microsoft.com/mssql-tools
 
     - name: Setup .NET
-      uses: actions/setup-dotnet@v4
+      uses: actions/setup-dotnet@v5
       with:
         dotnet-version: ${{ env.DOTNET_VERSION }}
       

--- a/.github/workflows/pr-mnlth-full.yml
+++ b/.github/workflows/pr-mnlth-full.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Developer Cert
         run: |
@@ -27,11 +27,11 @@ jobs:
           ls -lah
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Build Docker image locally
         id: push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: ${{ vars.MONOLITH_SLN_PATH }}
           file: ${{ vars.MONOLITH_SLN_PATH }}/src/ContosoUniversity.Mvc/Dockerfile
@@ -39,7 +39,7 @@ jobs:
           outputs: type=docker,dest=${{ runner.temp }}/cuweb.tar
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: cuweb
           path: ${{ runner.temp }}/cuweb.tar
@@ -54,10 +54,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Download artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: cuweb
           path: ${{ runner.temp }}
@@ -107,7 +107,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Install Docker Compose
       run: sudo curl -L "https://github.com/docker/compose/releases/download/v2.11.1/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
@@ -122,7 +122,7 @@ jobs:
         ls -lah
 
     - name: Download artifact
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         name: cuweb
         path: ${{ runner.temp }}
@@ -133,7 +133,7 @@ jobs:
         docker image ls -a
 
     - name: Setup .NET
-      uses: actions/setup-dotnet@v4
+      uses: actions/setup-dotnet@v5
       with:
         dotnet-version: ${{ env.DOTNET_VERSION }}
 
@@ -161,7 +161,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Install Docker Compose
       run: sudo curl -L "https://github.com/docker/compose/releases/download/v2.11.1/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
@@ -176,7 +176,7 @@ jobs:
         ls -lah
 
     - name: Download artifact
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         name: cuweb
         path: ${{ runner.temp }}
@@ -187,7 +187,7 @@ jobs:
         docker image ls -a
 
     - name: Setup .NET
-      uses: actions/setup-dotnet@v4
+      uses: actions/setup-dotnet@v5
       with:
         dotnet-version: ${{ env.DOTNET_VERSION }}
 

--- a/.github/workflows/pr-msvc-fast.yml
+++ b/.github/workflows/pr-msvc-fast.yml
@@ -22,10 +22,10 @@ jobs:
         working-directory: ${{ vars.MSERVICES_SLN_PATH }}
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       
     - name: Setup .NET
-      uses: actions/setup-dotnet@v4
+      uses: actions/setup-dotnet@v5
       with:
         dotnet-version: ${{ env.DOTNET_VERSION }}
 
@@ -46,10 +46,10 @@ jobs:
         working-directory: ${{ vars.MSERVICES_SLN_PATH }}
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Setup .NET
-      uses: actions/setup-dotnet@v4
+      uses: actions/setup-dotnet@v5
       with:
         dotnet-version: ${{ env.DOTNET_VERSION }}
 
@@ -108,10 +108,10 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Setup .NET
-      uses: actions/setup-dotnet@v4
+      uses: actions/setup-dotnet@v5
       with:
         dotnet-version: ${{ env.DOTNET_VERSION }}
 

--- a/.github/workflows/pr-msvc-full.yml
+++ b/.github/workflows/pr-msvc-full.yml
@@ -42,10 +42,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Developer Cert
         if: ${{ matrix.image_name == 'cuweb' }}
@@ -56,7 +56,7 @@ jobs:
 
       - name: Build Docker image locally
         id: push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: ${{ vars.MSERVICES_SLN_PATH }}
           file: ${{ vars.MSERVICES_SLN_PATH }}/${{ matrix.proj_path }}/Dockerfile
@@ -64,7 +64,7 @@ jobs:
           outputs: type=docker,dest=${{ runner.temp }}/${{ matrix.image_name }}.tar
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ matrix.image_name }}
           path: ${{ runner.temp }}/${{ matrix.image_name }}.tar
@@ -79,46 +79,46 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Download artifact | cuweb
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
           name: cuweb
           path: ${{ runner.temp }}
 
     - name: Download artifact | courses-api
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
           name: courses-api
           path: ${{ runner.temp }}
 
     - name: Download artifact | courses-worker
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
           name: courses-worker
           path: ${{ runner.temp }}
 
     - name: Download artifact | departments-api
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
           name: departments-api
           path: ${{ runner.temp }}
 
     - name: Download artifact | departments-worker
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
           name: departments-worker
           path: ${{ runner.temp }}
 
     - name: Download artifact | students-api
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
           name: students-api
           path: ${{ runner.temp }}
 
     - name: Download artifact | students-worker
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
           name: students-worker
           path: ${{ runner.temp }}
@@ -228,7 +228,7 @@ jobs:
       TEST_PROJ_PATH: ${{ vars.MSERVICES_SLN_PATH }}/test/system/ContosoUniversity.SystemTests
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Install Docker Compose
       run: sudo curl -L "https://github.com/docker/compose/releases/download/v2.11.1/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
@@ -243,43 +243,43 @@ jobs:
         ls -lah
 
     - name: Download artifact | cuweb
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         name: cuweb
         path: ${{ runner.temp }}
 
     - name: Download artifact | courses-api
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         name: courses-api
         path: ${{ runner.temp }}
 
     - name: Download artifact | courses-worker
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         name: courses-worker
         path: ${{ runner.temp }}
 
     - name: Download artifact | departments-api
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         name: departments-api
         path: ${{ runner.temp }}
 
     - name: Download artifact | departments-worker
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         name: departments-worker
         path: ${{ runner.temp }}
 
     - name: Download artifact | students-api
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         name: students-api
         path: ${{ runner.temp }}
 
     - name: Download artifact | students-worker
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         name: students-worker
         path: ${{ runner.temp }}
@@ -296,7 +296,7 @@ jobs:
         docker image ls -a
 
     - name: Setup .NET
-      uses: actions/setup-dotnet@v4
+      uses: actions/setup-dotnet@v5
       with:
         dotnet-version: ${{ env.DOTNET_VERSION }}
 
@@ -323,7 +323,7 @@ jobs:
       TEST_PROJ_PATH: ${{ vars.MSERVICES_SLN_PATH }}/test/e2e/ContosoUniversity.AcceptanceTests
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Install Docker Compose
       run: sudo curl -L "https://github.com/docker/compose/releases/download/v2.11.1/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
@@ -338,43 +338,43 @@ jobs:
         ls -lah
 
     - name: Download artifact | cuweb
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         name: cuweb
         path: ${{ runner.temp }}
 
     - name: Download artifact | courses-api
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         name: courses-api
         path: ${{ runner.temp }}
 
     - name: Download artifact | courses-worker
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         name: courses-worker
         path: ${{ runner.temp }}
 
     - name: Download artifact | departments-api
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         name: departments-api
         path: ${{ runner.temp }}
 
     - name: Download artifact | departments-worker
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         name: departments-worker
         path: ${{ runner.temp }}
 
     - name: Download artifact | students-api
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         name: students-api
         path: ${{ runner.temp }}
 
     - name: Download artifact | students-worker
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         name: students-worker
         path: ${{ runner.temp }}
@@ -391,7 +391,7 @@ jobs:
         docker image ls -a
 
     - name: Setup .NET
-      uses: actions/setup-dotnet@v4
+      uses: actions/setup-dotnet@v5
       with:
         dotnet-version: ${{ env.DOTNET_VERSION }}
 


### PR DESCRIPTION
This pull request updates the GitHub Actions workflows to use the latest versions of several commonly used actions, including those for checking out code, setting up .NET, Docker operations, AWS credential configuration, Terraform, and artifact management. These updates help ensure better security, performance, and compatibility with the latest features and bug fixes.

**CI/CD Workflow Action Updates**

* Updated `actions/checkout` to v6 and `actions/setup-dotnet` to v5 across all workflows, ensuring the use of the latest stable releases for code checkout and .NET setup (.github/workflows/codeql.yml, pr-mnlth-fast.yml, pr-mnlth-full.yml, pr-msvc-fast.yml, deploy-mnlth-prepare-artifacts.yml, deploy-mnlth-qa-aws-ecs-*, pr-msvc-full.yml).

* Updated Docker-related actions to their latest major versions, including `docker/setup-buildx-action` (v4), `docker/login-action` (v4), `docker/metadata-action` (v6), and `docker/build-push-action` (v7), as well as artifact upload/download actions to v7/v8 (.github/workflows/deploy-mnlth-prepare-artifacts.yml, pr-mnlth-full.yml, pr-msvc-full.yml).

* Updated AWS and Terraform actions to the latest major versions, improving cloud infrastructure provisioning and management workflows (.github/workflows/deploy-mnlth-qa-aws-ecs-provision.yml, deploy-mnlth-qa-aws-ecs-dispose.yml, deploy-mnlth-qa-aws-ecs-run.yml, deploy-mnlth-qa-aws-ecs-stop.yml).

These changes modernize our CI/CD pipelines, reduce technical debt, and position us for easier future maintenance.