### PR TITLE
CONTOSO: Refine Sdk refs for testing projects (#243)

### DIFF
--- a/apps/monolith/Directory.Packages.props
+++ b/apps/monolith/Directory.Packages.props
@@ -7,6 +7,8 @@
     <PackageVersion Include="FluentValidation.DependencyInjectionExtensions" Version="12.1.1" />
     <PackageVersion Include="MediatR" Version="14.1.0" />
     <PackageVersion Include="AspNetCore.HealthChecks.UI.Client" Version="9.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.3" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.3" />
     <PackageVersion Include="Microsoft.Extensions.Http" Version="8.0.1" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="10.0.3" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.3">

--- a/apps/monolith/Directory.Packages.props
+++ b/apps/monolith/Directory.Packages.props
@@ -7,7 +7,6 @@
     <PackageVersion Include="FluentValidation.DependencyInjectionExtensions" Version="12.1.1" />
     <PackageVersion Include="MediatR" Version="14.1.0" />
     <PackageVersion Include="AspNetCore.HealthChecks.UI.Client" Version="9.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.3" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.3" />
     <PackageVersion Include="Microsoft.Extensions.Http" Version="8.0.1" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="10.0.3" />

--- a/apps/monolith/test/e2e/ContosoUniversity.AcceptanceTests/ContosoUniversity.AcceptanceTests.csproj
+++ b/apps/monolith/test/e2e/ContosoUniversity.AcceptanceTests/ContosoUniversity.AcceptanceTests.csproj
@@ -1,8 +1,11 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <ItemGroup>
         <PackageReference Include="Ductus.FluentDocker" />
         <PackageReference Include="FluentAssertions" />
+        <PackageReference Include="Microsoft.Extensions.Configuration" />
+        <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" />
+        <PackageReference Include="Microsoft.Extensions.Configuration.Json" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" />
         <PackageReference Include="Microsoft.Playwright" />
         <PackageReference Include="Microsoft.Playwright.NUnit" />
@@ -11,6 +14,12 @@
         <PackageReference Include="coverlet.collector" />
         <PackageReference Include="SpecFlow" />
         <PackageReference Include="SpecFlow.NUnit" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <Content Include="testsettings.json">
+            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        </Content>
     </ItemGroup>
 
 </Project>

--- a/apps/monolith/test/e2e/ContosoUniversity.AcceptanceTests/ContosoUniversity.AcceptanceTests.csproj
+++ b/apps/monolith/test/e2e/ContosoUniversity.AcceptanceTests/ContosoUniversity.AcceptanceTests.csproj
@@ -4,7 +4,6 @@
         <PackageReference Include="Ductus.FluentDocker" />
         <PackageReference Include="FluentAssertions" />
         <PackageReference Include="Microsoft.Extensions.Configuration" />
-        <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" />
         <PackageReference Include="Microsoft.Extensions.Configuration.Json" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" />
         <PackageReference Include="Microsoft.Playwright" />

--- a/apps/monolith/test/integration/ContosoUniversity.Mvc.IntegrationTests/ContosoUniversity.Mvc.IntegrationTests.csproj
+++ b/apps/monolith/test/integration/ContosoUniversity.Mvc.IntegrationTests/ContosoUniversity.Mvc.IntegrationTests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <ItemGroup>
         <PackageReference Include="FluentAssertions" />
@@ -12,6 +12,12 @@
 
     <ItemGroup>
         <ProjectReference Include="..\..\..\src\ContosoUniversity.Mvc\ContosoUniversity.Mvc.csproj"/>
+    </ItemGroup>
+
+    <ItemGroup>
+        <Content Include="testsettings.json">
+            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        </Content>
     </ItemGroup>
 
 </Project>

--- a/apps/monolith/test/integration/ContosoUniversity.Mvc.IntegrationTests/CoursesController/CreateEndpointsTests.cs
+++ b/apps/monolith/test/integration/ContosoUniversity.Mvc.IntegrationTests/CoursesController/CreateEndpointsTests.cs
@@ -36,7 +36,7 @@ public class CreateEndpointsTests :
             ["DepartmentId"] = "dab7e678-e3e7-4471-8282-96fe52e5c16f"
         });
 
-        var response = await _httpClient.PostAsync(new Uri("/Courses/Create"), postContent);
+        var response = await _httpClient.PostAsync(new Uri("/Courses/Create", UriKind.Relative), postContent);
 
         response.EnsureSuccessStatusCode();
 

--- a/apps/monolith/test/integration/ContosoUniversity.Mvc.IntegrationTests/HeaderNavigationTests.cs
+++ b/apps/monolith/test/integration/ContosoUniversity.Mvc.IntegrationTests/HeaderNavigationTests.cs
@@ -35,7 +35,7 @@ public class HeaderNavigationTests :
     [InlineData("/Departments")]
     public async Task HeaderMenu_Smoke_ReturnsOk(string path)
     {
-        HttpResponseMessage response = await _httpClient.GetAsync(new Uri(path));
+        HttpResponseMessage response = await _httpClient.GetAsync(new Uri(path, UriKind.Relative));
 
         response.EnsureSuccessStatusCode();
         response.Content.Headers.ContentType?.ToString().Should().Be("text/html; charset=utf-8");

--- a/apps/monolith/test/integration/ContosoUniversity.Mvc.IntegrationTests/HealthCheck/InfraExistsTests.cs
+++ b/apps/monolith/test/integration/ContosoUniversity.Mvc.IntegrationTests/HealthCheck/InfraExistsTests.cs
@@ -33,7 +33,7 @@ public class InfraExistsTests :
     [InlineData("/health/liveness")]
     public async Task Health_ReturnsHealthy(string path)
     {
-        HttpResponseMessage response = await _httpClient.GetAsync(new Uri(path));
+        HttpResponseMessage response = await _httpClient.GetAsync(new Uri(path, UriKind.Relative));
 
         response.Should().BeSuccessful();
         response.Content.Headers.ContentType?.ToString().Should().Be("application/json");

--- a/apps/monolith/test/integration/ContosoUniversity.Mvc.IntegrationTests/HealthCheck/NoInfraTests.cs
+++ b/apps/monolith/test/integration/ContosoUniversity.Mvc.IntegrationTests/HealthCheck/NoInfraTests.cs
@@ -33,7 +33,7 @@ public class NoInfraTests :
     [InlineData("/health/liveness")]
     public async Task Health_ReturnsUnhealthy(string path)
     {
-        HttpResponseMessage response = await _httpClient.GetAsync(new Uri(path));
+        HttpResponseMessage response = await _httpClient.GetAsync(new Uri(path, UriKind.Relative));
 
         response.StatusCode.Should().Be(HttpStatusCode.ServiceUnavailable);
         response.Content.Headers.ContentType?.ToString().Should().Be("application/json");

--- a/apps/monolith/test/system/ContosoUniversity.SystemTests/ContosoUniversity.SystemTests.csproj
+++ b/apps/monolith/test/system/ContosoUniversity.SystemTests/ContosoUniversity.SystemTests.csproj
@@ -1,14 +1,24 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+<Project Sdk="Microsoft.NET.Sdk">
 
     <ItemGroup>
         <PackageReference Include="Ductus.FluentDocker" />
         <PackageReference Include="FluentAssertions" />
+        <PackageReference Include="Microsoft.Extensions.Configuration" />
+        <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" />
+        <PackageReference Include="Microsoft.Extensions.Configuration.Json" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" />
         <PackageReference Include="Microsoft.Playwright" />
         <PackageReference Include="Microsoft.Playwright.NUnit" />
         <PackageReference Include="NUnit" />
         <PackageReference Include="NUnit3TestAdapter" />
         <PackageReference Include="coverlet.collector" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <Content Include="testsettings.json">
+            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        </Content>
     </ItemGroup>
 
 </Project>

--- a/apps/monolith/test/system/ContosoUniversity.SystemTests/ContosoUniversity.SystemTests.csproj
+++ b/apps/monolith/test/system/ContosoUniversity.SystemTests/ContosoUniversity.SystemTests.csproj
@@ -1,10 +1,9 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <ItemGroup>
         <PackageReference Include="Ductus.FluentDocker" />
         <PackageReference Include="FluentAssertions" />
         <PackageReference Include="Microsoft.Extensions.Configuration" />
-        <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" />
         <PackageReference Include="Microsoft.Extensions.Configuration.Json" />
         <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" />

--- a/apps/mservices/Directory.Packages.props
+++ b/apps/mservices/Directory.Packages.props
@@ -27,6 +27,7 @@
     <PackageVersion Include="Microsoft.Extensions.Configuration" Version="10.0.3" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.3" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="10.0.3" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.3" />
     <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="10.0.3" />
     <PackageVersion Include="Ductus.FluentDocker" Version="2.85.0" />
     <PackageVersion Include="FluentAssertions" Version="[7.0.0]" />

--- a/apps/mservices/test/e2e/ContosoUniversity.AcceptanceTests/ContosoUniversity.AcceptanceTests.csproj
+++ b/apps/mservices/test/e2e/ContosoUniversity.AcceptanceTests/ContosoUniversity.AcceptanceTests.csproj
@@ -1,8 +1,10 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+<Project Sdk="Microsoft.NET.Sdk">
 
     <ItemGroup>
         <PackageReference Include="Ductus.FluentDocker" />
         <PackageReference Include="FluentAssertions" />
+        <PackageReference Include="Microsoft.Extensions.Configuration" />
+        <PackageReference Include="Microsoft.Extensions.Configuration.Json" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" />
         <PackageReference Include="Microsoft.Playwright" />
         <PackageReference Include="Microsoft.Playwright.NUnit" />
@@ -11,6 +13,12 @@
         <PackageReference Include="coverlet.collector" />
         <PackageReference Include="SpecFlow" />
         <PackageReference Include="SpecFlow.NUnit" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <Content Include="testsettings.json">
+            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        </Content>
     </ItemGroup>
 
 </Project>

--- a/apps/mservices/test/integration/ContosoUniversity.Mvc.IntegrationTests/ContosoUniversity.Mvc.IntegrationTests.csproj
+++ b/apps/mservices/test/integration/ContosoUniversity.Mvc.IntegrationTests/ContosoUniversity.Mvc.IntegrationTests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <ItemGroup>
         <PackageReference Include="FluentAssertions" />
@@ -12,6 +12,12 @@
 
     <ItemGroup>
         <ProjectReference Include="..\..\..\src\ContosoUniversity.Mvc\ContosoUniversity.Mvc.csproj"/>
+    </ItemGroup>
+
+    <ItemGroup>
+        <Content Include="testsettings.json">
+            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        </Content>
     </ItemGroup>
 
 </Project>

--- a/apps/mservices/test/integration/ContosoUniversity.Mvc.IntegrationTests/HeaderNavigationTests.cs
+++ b/apps/mservices/test/integration/ContosoUniversity.Mvc.IntegrationTests/HeaderNavigationTests.cs
@@ -35,7 +35,7 @@ public class HeaderNavigationTests :
     [InlineData("/Departments")]
     public async Task HeaderMenu_Smoke_ReturnsOk(string path)
     {
-        HttpResponseMessage response = await _httpClient.GetAsync(new Uri(path));
+        HttpResponseMessage response = await _httpClient.GetAsync(new Uri(path, UriKind.Relative));
 
         response.EnsureSuccessStatusCode();
         response.Content.Headers.ContentType?.ToString().Should().Be("text/html; charset=utf-8");

--- a/apps/mservices/test/integration/Courses.Api.IntegrationTests/Courses.Api.IntegrationTests.csproj
+++ b/apps/mservices/test/integration/Courses.Api.IntegrationTests/Courses.Api.IntegrationTests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <ImplicitUsings>enable</ImplicitUsings>
@@ -21,6 +21,12 @@
 
     <ItemGroup>
         <Using Include="Xunit"/>
+    </ItemGroup>
+
+    <ItemGroup>
+        <Content Include="testsettings.json">
+            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        </Content>
     </ItemGroup>
 
 </Project>

--- a/apps/mservices/test/integration/Courses.Api.IntegrationTests/HealthCheck/InfraExistsTests.cs
+++ b/apps/mservices/test/integration/Courses.Api.IntegrationTests/HealthCheck/InfraExistsTests.cs
@@ -1,6 +1,7 @@
 namespace Courses.Api.IntegrationTests.HealthCheck;
 
 using System.Net.Http;
+using System.Net.Http.Json;
 using System.Threading.Tasks;
 
 using FluentAssertions;
@@ -37,7 +38,7 @@ public class InfraExistsTests :
     public async Task Health_ReturnsHealthy(string path)
     {
         await Task.Delay(1000);
-        HttpResponseMessage response = await _httpClient.GetAsync(new Uri(path));
+        HttpResponseMessage response = await _httpClient.GetAsync(new Uri(path, UriKind.Relative));
 
         response.Should().BeSuccessful();
         response.Content.Headers.ContentType?.ToString().Should().Be("application/json");

--- a/apps/mservices/test/integration/Courses.Api.IntegrationTests/HealthCheck/NoInfraTests.cs
+++ b/apps/mservices/test/integration/Courses.Api.IntegrationTests/HealthCheck/NoInfraTests.cs
@@ -1,6 +1,7 @@
 namespace Courses.Api.IntegrationTests.HealthCheck;
 
 using System.Net;
+using System.Net.Http.Json;
 using System.Threading.Tasks;
 
 using Api;
@@ -34,7 +35,7 @@ public class NoInfraTests :
     [InlineData("/health/liveness")]
     public async Task Health_ReturnsUnhealthy(string path)
     {
-        HttpResponseMessage response = await _httpClient.GetAsync(new Uri(path));
+        HttpResponseMessage response = await _httpClient.GetAsync(new Uri(path, UriKind.Relative));
 
         response.StatusCode.Should().Be(HttpStatusCode.ServiceUnavailable);
         response.Content.Headers.ContentType?.ToString().Should().Be("application/json");

--- a/apps/mservices/test/integration/Courses.Api.IntegrationTests/MacrosActionsExtensions.cs
+++ b/apps/mservices/test/integration/Courses.Api.IntegrationTests/MacrosActionsExtensions.cs
@@ -1,5 +1,7 @@
 namespace Courses.Api.IntegrationTests;
 
+using System.Net.Http.Json;
+
 using Models;
 
 static class MacrosActionsExtensions

--- a/apps/mservices/test/integration/Courses.Api.IntegrationTests/ReadWrite/CreateTests.cs
+++ b/apps/mservices/test/integration/Courses.Api.IntegrationTests/ReadWrite/CreateTests.cs
@@ -1,6 +1,7 @@
 namespace Courses.Api.IntegrationTests.ReadWrite;
 
 using System.Net;
+using System.Net.Http.Json;
 
 using FluentAssertions;
 

--- a/apps/mservices/test/integration/Courses.Api.IntegrationTests/ReadWrite/UpdateTests.cs
+++ b/apps/mservices/test/integration/Courses.Api.IntegrationTests/ReadWrite/UpdateTests.cs
@@ -1,6 +1,7 @@
 namespace Courses.Api.IntegrationTests.ReadWrite;
 
 using System.Net;
+using System.Net.Http.Json;
 
 using FluentAssertions;
 

--- a/apps/mservices/test/integration/Courses.Worker.IntegrationTests/Courses.Worker.IntegrationTests.csproj
+++ b/apps/mservices/test/integration/Courses.Worker.IntegrationTests/Courses.Worker.IntegrationTests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <ImplicitUsings>enable</ImplicitUsings>
@@ -21,6 +21,12 @@
 
     <ItemGroup>
         <Using Include="Xunit"/>
+    </ItemGroup>
+
+    <ItemGroup>
+        <Content Include="testsettings.json">
+            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        </Content>
     </ItemGroup>
 
 </Project>

--- a/apps/mservices/test/integration/Courses.Worker.IntegrationTests/HealthCheck/InfraExistsTests.cs
+++ b/apps/mservices/test/integration/Courses.Worker.IntegrationTests/HealthCheck/InfraExistsTests.cs
@@ -1,6 +1,7 @@
 namespace Courses.Worker.IntegrationTests.HealthCheck;
 
 using System.Net.Http;
+using System.Net.Http.Json;
 using System.Threading.Tasks;
 
 using FluentAssertions;
@@ -37,7 +38,7 @@ public class InfraExistsTests :
     public async Task Health_ReturnsHealthy(string path)
     {
         await Task.Delay(1000);
-        HttpResponseMessage response = await _httpClient.GetAsync(new Uri(path));
+        HttpResponseMessage response = await _httpClient.GetAsync(new Uri(path, UriKind.Relative));
 
         response.Should().BeSuccessful();
         response.Content.Headers.ContentType?.ToString().Should().Be("application/json");

--- a/apps/mservices/test/integration/Courses.Worker.IntegrationTests/HealthCheck/NoInfraTests.cs
+++ b/apps/mservices/test/integration/Courses.Worker.IntegrationTests/HealthCheck/NoInfraTests.cs
@@ -34,7 +34,7 @@ public class NoInfraTests :
     [InlineData("/health/liveness")]
     public async Task Health_ReturnsUnhealthy(string path)
     {
-        HttpResponseMessage response = await _httpClient.GetAsync(new Uri(path));
+        HttpResponseMessage response = await _httpClient.GetAsync(new Uri(path, UriKind.Relative));
 
         response.StatusCode.Should().Be(HttpStatusCode.ServiceUnavailable);
         response.Content.Headers.ContentType?.ToString().Should().Be("application/json");

--- a/apps/mservices/test/integration/Departments.Api.IntegrationTests/Departments.Api.IntegrationTests.csproj
+++ b/apps/mservices/test/integration/Departments.Api.IntegrationTests/Departments.Api.IntegrationTests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <ImplicitUsings>enable</ImplicitUsings>
@@ -21,6 +21,12 @@
 
     <ItemGroup>
         <Using Include="Xunit"/>
+    </ItemGroup>
+
+    <ItemGroup>
+        <Content Include="testsettings.json">
+            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        </Content>
     </ItemGroup>
 
 </Project>

--- a/apps/mservices/test/integration/Departments.Api.IntegrationTests/HealthCheck/InfraExistsTests.cs
+++ b/apps/mservices/test/integration/Departments.Api.IntegrationTests/HealthCheck/InfraExistsTests.cs
@@ -1,6 +1,7 @@
 namespace Departments.Api.IntegrationTests.HealthCheck;
 
 using System.Net.Http;
+using System.Net.Http.Json;
 using System.Threading.Tasks;
 
 using FluentAssertions;
@@ -37,7 +38,7 @@ public class InfraExistsTests :
     public async Task Health_ReturnsHealthy(string path)
     {
         await Task.Delay(1000);
-        HttpResponseMessage response = await _httpClient.GetAsync(new Uri(path));
+        HttpResponseMessage response = await _httpClient.GetAsync(new Uri(path, UriKind.Relative));
 
         response.Should().BeSuccessful();
         response.Content.Headers.ContentType?.ToString().Should().Be("application/json");

--- a/apps/mservices/test/integration/Departments.Api.IntegrationTests/HealthCheck/NoInfraTests.cs
+++ b/apps/mservices/test/integration/Departments.Api.IntegrationTests/HealthCheck/NoInfraTests.cs
@@ -34,7 +34,7 @@ public class NoInfraTests :
     [InlineData("/health/liveness")]
     public async Task Health_ReturnsUnhealthy(string path)
     {
-        HttpResponseMessage response = await _httpClient.GetAsync(new Uri(path));
+        HttpResponseMessage response = await _httpClient.GetAsync(new Uri(path, UriKind.Relative));
 
         response.StatusCode.Should().Be(HttpStatusCode.ServiceUnavailable);
         response.Content.Headers.ContentType?.ToString().Should().Be("application/json");

--- a/apps/mservices/test/integration/Departments.Api.IntegrationTests/MacrosActionsExtensions.cs
+++ b/apps/mservices/test/integration/Departments.Api.IntegrationTests/MacrosActionsExtensions.cs
@@ -1,5 +1,7 @@
 namespace Departments.Api.IntegrationTests;
 
+using System.Net.Http.Json;
+
 using Models;
 
 static class MacrosActionsExtensions

--- a/apps/mservices/test/integration/Departments.Api.IntegrationTests/ReadWrite/Departments/CreateTests.cs
+++ b/apps/mservices/test/integration/Departments.Api.IntegrationTests/ReadWrite/Departments/CreateTests.cs
@@ -1,6 +1,7 @@
 namespace Departments.Api.IntegrationTests.ReadWrite.Departments;
 
 using System.Net;
+using System.Net.Http.Json;
 
 using FluentAssertions;
 

--- a/apps/mservices/test/integration/Departments.Api.IntegrationTests/ReadWrite/Departments/UpdateTests.cs
+++ b/apps/mservices/test/integration/Departments.Api.IntegrationTests/ReadWrite/Departments/UpdateTests.cs
@@ -1,6 +1,7 @@
 namespace Departments.Api.IntegrationTests.ReadWrite.Departments;
 
 using System.Net;
+using System.Net.Http.Json;
 
 using FluentAssertions;
 

--- a/apps/mservices/test/integration/Departments.Api.IntegrationTests/ReadWrite/Instructors/CreateTests.cs
+++ b/apps/mservices/test/integration/Departments.Api.IntegrationTests/ReadWrite/Instructors/CreateTests.cs
@@ -1,6 +1,7 @@
 namespace Departments.Api.IntegrationTests.ReadWrite.Instructors;
 
 using System.Net;
+using System.Net.Http.Json;
 
 using FluentAssertions;
 

--- a/apps/mservices/test/integration/Departments.Api.IntegrationTests/ReadWrite/Instructors/UpdateTests.cs
+++ b/apps/mservices/test/integration/Departments.Api.IntegrationTests/ReadWrite/Instructors/UpdateTests.cs
@@ -1,6 +1,7 @@
 namespace Departments.Api.IntegrationTests.ReadWrite.Instructors;
 
 using System.Net;
+using System.Net.Http.Json;
 
 using FluentAssertions;
 

--- a/apps/mservices/test/integration/Departments.Worker.IntegrationTests/Departments.Worker.IntegrationTests.csproj
+++ b/apps/mservices/test/integration/Departments.Worker.IntegrationTests/Departments.Worker.IntegrationTests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <ImplicitUsings>enable</ImplicitUsings>
@@ -21,6 +21,12 @@
 
     <ItemGroup>
         <Using Include="Xunit"/>
+    </ItemGroup>
+
+    <ItemGroup>
+        <Content Include="testsettings.json">
+            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        </Content>
     </ItemGroup>
 
 </Project>

--- a/apps/mservices/test/integration/Departments.Worker.IntegrationTests/HealthCheck/InfraExistsTests.cs
+++ b/apps/mservices/test/integration/Departments.Worker.IntegrationTests/HealthCheck/InfraExistsTests.cs
@@ -1,6 +1,7 @@
 namespace Departments.Worker.IntegrationTests.HealthCheck;
 
 using System.Net.Http;
+using System.Net.Http.Json;
 using System.Threading.Tasks;
 
 using FluentAssertions;
@@ -37,7 +38,7 @@ public class InfraExistsTests :
     public async Task Health_ReturnsHealthy(string path)
     {
         await Task.Delay(1000);
-        HttpResponseMessage response = await _httpClient.GetAsync(new Uri(path));
+        HttpResponseMessage response = await _httpClient.GetAsync(new Uri(path, UriKind.Relative));
 
         response.Should().BeSuccessful();
         response.Content.Headers.ContentType?.ToString().Should().Be("application/json");

--- a/apps/mservices/test/integration/Departments.Worker.IntegrationTests/HealthCheck/NoInfraTests.cs
+++ b/apps/mservices/test/integration/Departments.Worker.IntegrationTests/HealthCheck/NoInfraTests.cs
@@ -36,7 +36,7 @@ public class NoInfraTests :
     [InlineData("/health/liveness")]
     public async Task Health_ReturnsUnhealthy(string path)
     {
-        HttpResponseMessage response = await _httpClient.GetAsync(new Uri(path));
+        HttpResponseMessage response = await _httpClient.GetAsync(new Uri(path, UriKind.Relative));
 
         response.StatusCode.Should().Be(HttpStatusCode.ServiceUnavailable);
         response.Content.Headers.ContentType?.ToString().Should().Be("application/json");

--- a/apps/mservices/test/integration/Students.Api.IntegrationTests/HealthCheck/InfraExistsTests.cs
+++ b/apps/mservices/test/integration/Students.Api.IntegrationTests/HealthCheck/InfraExistsTests.cs
@@ -1,6 +1,7 @@
 namespace Students.Api.IntegrationTests.HealthCheck;
 
 using System.Net.Http;
+using System.Net.Http.Json;
 using System.Threading.Tasks;
 
 using FluentAssertions;
@@ -33,7 +34,7 @@ public class InfraExistsTests :
     [InlineData("/health/liveness")]
     public async Task Health_ReturnsHealthy(string path)
     {
-        HttpResponseMessage response = await _httpClient.GetAsync(new Uri(path));
+        HttpResponseMessage response = await _httpClient.GetAsync(new Uri(path, UriKind.Relative));
 
         response.Should().BeSuccessful();
         response.Content.Headers.ContentType?.ToString().Should().Be("application/json");

--- a/apps/mservices/test/integration/Students.Api.IntegrationTests/HealthCheck/NoInfraTests.cs
+++ b/apps/mservices/test/integration/Students.Api.IntegrationTests/HealthCheck/NoInfraTests.cs
@@ -34,7 +34,7 @@ public class NoInfraTests :
     [InlineData("/health/liveness")]
     public async Task Health_ReturnsUnhealthy(string path)
     {
-        HttpResponseMessage response = await _httpClient.GetAsync(new Uri(path));
+        HttpResponseMessage response = await _httpClient.GetAsync(new Uri(path, UriKind.Relative));
 
         response.StatusCode.Should().Be(HttpStatusCode.ServiceUnavailable);
         response.Content.Headers.ContentType?.ToString().Should().Be("application/json");

--- a/apps/mservices/test/integration/Students.Api.IntegrationTests/MacrosActionsExtensions.cs
+++ b/apps/mservices/test/integration/Students.Api.IntegrationTests/MacrosActionsExtensions.cs
@@ -1,5 +1,7 @@
 namespace Students.Api.IntegrationTests;
 
+using System.Net.Http.Json;
+
 using Models;
 
 static class MacrosActionsExtensions

--- a/apps/mservices/test/integration/Students.Api.IntegrationTests/ReadWrite/CreateTests.cs
+++ b/apps/mservices/test/integration/Students.Api.IntegrationTests/ReadWrite/CreateTests.cs
@@ -1,6 +1,7 @@
 namespace Students.Api.IntegrationTests.ReadWrite;
 
 using System.Net;
+using System.Net.Http.Json;
 
 using FluentAssertions;
 

--- a/apps/mservices/test/integration/Students.Api.IntegrationTests/ReadWrite/UpdateTests.cs
+++ b/apps/mservices/test/integration/Students.Api.IntegrationTests/ReadWrite/UpdateTests.cs
@@ -1,6 +1,7 @@
 namespace Students.Api.IntegrationTests.ReadWrite;
 
 using System.Net;
+using System.Net.Http.Json;
 
 using FluentAssertions;
 

--- a/apps/mservices/test/integration/Students.Api.IntegrationTests/Students.Api.IntegrationTests.csproj
+++ b/apps/mservices/test/integration/Students.Api.IntegrationTests/Students.Api.IntegrationTests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <ImplicitUsings>enable</ImplicitUsings>
@@ -21,6 +21,12 @@
 
     <ItemGroup>
         <Using Include="Xunit"/>
+    </ItemGroup>
+
+    <ItemGroup>
+        <Content Include="testsettings.json">
+            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        </Content>
     </ItemGroup>
 
 </Project>

--- a/apps/mservices/test/integration/Students.Worker.IntegrationTests/HealthCheck/InfraExistsTests.cs
+++ b/apps/mservices/test/integration/Students.Worker.IntegrationTests/HealthCheck/InfraExistsTests.cs
@@ -1,6 +1,7 @@
 namespace Students.Worker.IntegrationTests.HealthCheck;
 
 using System.Net.Http;
+using System.Net.Http.Json;
 using System.Threading.Tasks;
 
 using FluentAssertions;
@@ -37,7 +38,7 @@ public class InfraExistsTests :
     public async Task Health_ReturnsHealthy(string path)
     {
         await Task.Delay(1000);
-        HttpResponseMessage response = await _httpClient.GetAsync(new Uri(path));
+        HttpResponseMessage response = await _httpClient.GetAsync(new Uri(path, UriKind.Relative));
 
         response.Should().BeSuccessful();
         response.Content.Headers.ContentType?.ToString().Should().Be("application/json");

--- a/apps/mservices/test/integration/Students.Worker.IntegrationTests/HealthCheck/NoInfraTests.cs
+++ b/apps/mservices/test/integration/Students.Worker.IntegrationTests/HealthCheck/NoInfraTests.cs
@@ -36,7 +36,7 @@ public class NoInfraTests :
     [InlineData("/health/liveness")]
     public async Task Health_ReturnsUnhealthy(string path)
     {
-        HttpResponseMessage response = await _httpClient.GetAsync(new Uri(path));
+        HttpResponseMessage response = await _httpClient.GetAsync(new Uri(path, UriKind.Relative));
 
         response.StatusCode.Should().Be(HttpStatusCode.ServiceUnavailable);
         response.Content.Headers.ContentType?.ToString().Should().Be("application/json");

--- a/apps/mservices/test/integration/Students.Worker.IntegrationTests/Students.Worker.IntegrationTests.csproj
+++ b/apps/mservices/test/integration/Students.Worker.IntegrationTests/Students.Worker.IntegrationTests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <ImplicitUsings>enable</ImplicitUsings>
@@ -21,6 +21,12 @@
 
     <ItemGroup>
         <Using Include="Xunit"/>
+    </ItemGroup>
+
+    <ItemGroup>
+        <Content Include="testsettings.json">
+            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        </Content>
     </ItemGroup>
 
 </Project>

--- a/apps/mservices/test/system/ContosoUniversity.SystemTests/ContosoUniversity.SystemTests.csproj
+++ b/apps/mservices/test/system/ContosoUniversity.SystemTests/ContosoUniversity.SystemTests.csproj
@@ -1,14 +1,23 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <ItemGroup>
         <PackageReference Include="Ductus.FluentDocker" />
         <PackageReference Include="FluentAssertions" />
+        <PackageReference Include="Microsoft.Extensions.Configuration" />
+        <PackageReference Include="Microsoft.Extensions.Configuration.Json" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" />
         <PackageReference Include="Microsoft.Playwright" />
         <PackageReference Include="Microsoft.Playwright.NUnit" />
         <PackageReference Include="NUnit" />
         <PackageReference Include="NUnit3TestAdapter" />
         <PackageReference Include="coverlet.collector" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <Content Include="testsettings.json">
+            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        </Content>
     </ItemGroup>
 
 </Project>


### PR DESCRIPTION
This pull request makes several improvements to the test projects and dependency management for both the monolith and microservices solutions. The main changes include standardizing test project configurations, updating package dependencies, ensuring test settings are correctly copied, and fixing issues with HTTP request URIs in integration tests.

**Dependency management:**

* Added or updated `Microsoft.Extensions.DependencyInjection` to version `10.0.3` in both `apps/monolith/Directory.Packages.props` and `apps/mservices/Directory.Packages.props` for consistency across projects. [[1]](diffhunk://#diff-118d33c27201ae7755b7988a7f061d3e2af9df0b90547b1d0a7bdf68e6ff72fbR10) [[2]](diffhunk://#diff-9fc3a5b14cd432439d4c958ef6aab163b9188030106f2bc07062e521dc30f417R30)
* Added `Microsoft.Extensions.Configuration` and `Microsoft.Extensions.Configuration.Json` as test dependencies in acceptance and system test projects for both monolith and microservices. [[1]](diffhunk://#diff-5339ab7e727288e3db2ea64440a997a2e305c905bc71827755e7f9c24ac067d7L1-R7) [[2]](diffhunk://#diff-d55c01f628bd3bc5616662cc8aefdacd31284571bd7e5c2987ba47fb3c5de746L1-R7) [[3]](diffhunk://#diff-10b8ebd7dbc662776c59ed6e7c4e1e4722b630e9c7f641c434b51c59329aa9baL1-R8)

**Test project configuration:**

* Changed test project SDKs from `Microsoft.NET.Sdk.Web` to `Microsoft.NET.Sdk` where appropriate, aligning with best practices for test projects. [[1]](diffhunk://#diff-5339ab7e727288e3db2ea64440a997a2e305c905bc71827755e7f9c24ac067d7L1-R7) [[2]](diffhunk://#diff-8e02fdaad47879fa2b419d39260e2ac59685acce470318de840f31b22886b2f4L1-R1) [[3]](diffhunk://#diff-d55c01f628bd3bc5616662cc8aefdacd31284571bd7e5c2987ba47fb3c5de746L1-R7) [[4]](diffhunk://#diff-705948fa495cec002ec6d0e0e9e142bb2f1a427c8afdf2ff1276dc0d74ca3d0aL1-R1) [[5]](diffhunk://#diff-f27e600fe7bf092a5999b65e85231b7bdaa28d56aaf64c0aeb59145ccb426fb5L1-R1) [[6]](diffhunk://#diff-359e19078a02f5267606199e7b04a3a763ec6cfe85b30b7c72ef5e4376aface5L1-R1) [[7]](diffhunk://#diff-10b8ebd7dbc662776c59ed6e7c4e1e4722b630e9c7f641c434b51c59329aa9baL1-R8)

**Test settings management:**

* Ensured `testsettings.json` is included and copied to the output directory in all test projects, improving test configuration consistency. [[1]](diffhunk://#diff-5339ab7e727288e3db2ea64440a997a2e305c905bc71827755e7f9c24ac067d7R18-R23) [[2]](diffhunk://#diff-8e02fdaad47879fa2b419d39260e2ac59685acce470318de840f31b22886b2f4R17-R22) [[3]](diffhunk://#diff-d55c01f628bd3bc5616662cc8aefdacd31284571bd7e5c2987ba47fb3c5de746R18-R23) [[4]](diffhunk://#diff-705948fa495cec002ec6d0e0e9e142bb2f1a427c8afdf2ff1276dc0d74ca3d0aR17-R22) [[5]](diffhunk://#diff-f27e600fe7bf092a5999b65e85231b7bdaa28d56aaf64c0aeb59145ccb426fb5R26-R31) [[6]](diffhunk://#diff-359e19078a02f5267606199e7b04a3a763ec6cfe85b30b7c72ef5e4376aface5R26-R31) [[7]](diffhunk://#diff-10b8ebd7dbc662776c59ed6e7c4e1e4722b630e9c7f641c434b51c59329aa9baR17-R22)

**Integration test improvements:**

* Updated all HTTP requests in integration tests to use `UriKind.Relative`, fixing potential issues with URI resolution and improving test reliability. [[1]](diffhunk://#diff-711d9f9f0e605c0fa67a533a91b54f913ea8bc2dd957681847073084bab05855L39-R39) [[2]](diffhunk://#diff-80a05d499d516fc579ec63a318ce833df90ef5d681c4d12f1c53e3153a740ebeL38-R38) [[3]](diffhunk://#diff-a388fbdf04f22bdda625f012a667fc8a8664a20936f7a4c6933cdc82316a913cL36-R36) [[4]](diffhunk://#diff-7ad3a9c63e3a1f7502d8fb1e6e0ecfdc7d457acf99cdc91f704f0a62b8c797a6L36-R36) [[5]](diffhunk://#diff-484cd83e8086f30a7c4b3e119d247dac9ec6324a807aed339a58b907cecac395L38-R38) [[6]](diffhunk://#diff-2a8c34d03693c7eefc0f8ef1b8163e1aa7eb912ccd35d993de7445d2e0e72190L40-R41) [[7]](diffhunk://#diff-d59949ab1e95d09938fb69fe26e37569dbcb75dde2319bdea1fa7fb28e457cabL37-R38) [[8]](diffhunk://#diff-98d766e07ed2e772c16a1b832fb928e3ba60123fe58d7d78daef62ba31998cd7L40-R41)
* Added missing `System.Net.Http.Json` usings to relevant test files, ensuring compatibility with strongly-typed HTTP content operations. [[1]](diffhunk://#diff-2a8c34d03693c7eefc0f8ef1b8163e1aa7eb912ccd35d993de7445d2e0e72190R4) [[2]](diffhunk://#diff-d59949ab1e95d09938fb69fe26e37569dbcb75dde2319bdea1fa7fb28e457cabR4) [[3]](diffhunk://#diff-07c1534f14871d4905915b344a6f6a92b4eff88d420a900e5608634231a32c8cR3-R4) [[4]](diffhunk://#diff-aa9dcda08d611b2da564a98847a5343e4c6aa26330f97720f517ce1a2ec40503R4) [[5]](diffhunk://#diff-697b17cc81ba3080eeeb7c2bf709b5249687a60bc6bae836b28927d541c05795R4) [[6]](diffhunk://#diff-98d766e07ed2e772c16a1b832fb928e3ba60123fe58d7d78daef62ba31998cd7R4)

These changes collectively improve the maintainability, reliability, and consistency of the test infrastructure across both solutions.