### PR TITLE
CONTOSO: Resolve `Recommended` suppressions (#231)

### DIFF
--- a/apps/monolith/.editorconfig
+++ b/apps/monolith/.editorconfig
@@ -82,7 +82,6 @@ dotnet_diagnostic.CS1591.severity = none # Missing XML comment for publicly visi
 
 # AnalysisMode: Recommended
 dotnet_diagnostic.CA1305.severity = none # Specify IFormatProvider
-dotnet_diagnostic.CA1716.severity = none # Identifiers should not match keywords
 dotnet_diagnostic.CA1852.severity = none # Seal internal types
 
 # AnalysisMode: All

--- a/apps/monolith/.editorconfig
+++ b/apps/monolith/.editorconfig
@@ -77,12 +77,12 @@ dotnet_diagnostic.IDE0051.severity = error # Remove unused private members
 dotnet_diagnostic.IDE0052.severity = error # Remove unread private member
 dotnet_diagnostic.IDE0290.severity = error # Use primary constructor
 
-# Global suppressions
+# Global compiler suppressions
 dotnet_diagnostic.CS1591.severity = none # Missing XML comment for publicly visible type or member
 
-# AnalysisMode: Recommended
-dotnet_diagnostic.CA1305.severity = none # Specify IFormatProvider
-dotnet_diagnostic.CA1852.severity = none # Seal internal types
+# Global analyser suppressions
+dotnet_diagnostic.CA1305.severity = none # Recommended - Specify IFormatProvider
+dotnet_diagnostic.CA1852.severity = none # Recommended - Seal internal types
 
 # AnalysisMode: All
 dotnet_diagnostic.CA1002.severity = none # Do not expose generic lists

--- a/apps/monolith/.editorconfig
+++ b/apps/monolith/.editorconfig
@@ -86,7 +86,6 @@ dotnet_diagnostic.CA1305.severity = none # Specify IFormatProvider
 dotnet_diagnostic.CA1707.severity = none # Identifiers should not contain underscores
 dotnet_diagnostic.CA1716.severity = none # Identifiers should not match keywords
 dotnet_diagnostic.CA1852.severity = none # Seal internal types
-dotnet_diagnostic.CA2201.severity = none # Do not raise reserved exception types
 
 # AnalysisMode: All
 dotnet_diagnostic.CA1002.severity = none # Do not expose generic lists

--- a/apps/monolith/.editorconfig
+++ b/apps/monolith/.editorconfig
@@ -81,7 +81,6 @@ dotnet_diagnostic.IDE0290.severity = error # Use primary constructor
 dotnet_diagnostic.CS1591.severity = none # Missing XML comment for publicly visible type or member
 
 # AnalysisMode: Recommended
-dotnet_diagnostic.CA1051.severity = none # Do not declare visible instance fields
 dotnet_diagnostic.CA1305.severity = none # Specify IFormatProvider
 dotnet_diagnostic.CA1707.severity = none # Identifiers should not contain underscores
 dotnet_diagnostic.CA1716.severity = none # Identifiers should not match keywords

--- a/apps/monolith/.editorconfig
+++ b/apps/monolith/.editorconfig
@@ -82,7 +82,6 @@ dotnet_diagnostic.CS1591.severity = none # Missing XML comment for publicly visi
 
 # AnalysisMode: Recommended
 dotnet_diagnostic.CA1305.severity = none # Specify IFormatProvider
-dotnet_diagnostic.CA1707.severity = none # Identifiers should not contain underscores
 dotnet_diagnostic.CA1716.severity = none # Identifiers should not match keywords
 dotnet_diagnostic.CA1852.severity = none # Seal internal types
 

--- a/apps/monolith/src/ContosoUniversity.Application/Contracts/Repositories/ReadOnly/Paging/OrderRequest.cs
+++ b/apps/monolith/src/ContosoUniversity.Application/Contracts/Repositories/ReadOnly/Paging/OrderRequest.cs
@@ -1,3 +1,0 @@
-namespace ContosoUniversity.Application.Contracts.Repositories.ReadOnly.Paging;
-
-public record OrderRequest(string SortOrder);

--- a/apps/monolith/src/ContosoUniversity.Application/Contracts/Repositories/ReadOnly/Paging/PageRequest.cs
+++ b/apps/monolith/src/ContosoUniversity.Application/Contracts/Repositories/ReadOnly/Paging/PageRequest.cs
@@ -1,3 +1,0 @@
-namespace ContosoUniversity.Application.Contracts.Repositories.ReadOnly.Paging;
-
-public record PageRequest(int PageNumber, int PageSize);

--- a/apps/monolith/src/ContosoUniversity.Application/Contracts/Repositories/ReadOnly/Paging/PagedResult.cs
+++ b/apps/monolith/src/ContosoUniversity.Application/Contracts/Repositories/ReadOnly/Paging/PagedResult.cs
@@ -1,3 +1,0 @@
-namespace ContosoUniversity.Application.Contracts.Repositories.ReadOnly.Paging;
-
-public record PagedResult<TEntity>(TEntity[] Items, PageInfo Info);

--- a/apps/monolith/src/ContosoUniversity.Application/Contracts/Repositories/ReadOnly/Paging/SearchRequest.cs
+++ b/apps/monolith/src/ContosoUniversity.Application/Contracts/Repositories/ReadOnly/Paging/SearchRequest.cs
@@ -1,3 +1,0 @@
-namespace ContosoUniversity.Application.Contracts.Repositories.ReadOnly.Paging;
-
-public record SearchRequest(string SearchString);

--- a/apps/monolith/src/ContosoUniversity.Application/Contracts/Repositories/Reads/ICoursesRoRepository.cs
+++ b/apps/monolith/src/ContosoUniversity.Application/Contracts/Repositories/Reads/ICoursesRoRepository.cs
@@ -1,4 +1,4 @@
-namespace ContosoUniversity.Application.Contracts.Repositories.ReadOnly;
+namespace ContosoUniversity.Application.Contracts.Repositories.Reads;
 
 using System;
 using System.Collections.Generic;

--- a/apps/monolith/src/ContosoUniversity.Application/Contracts/Repositories/Reads/IDepartmentsRoRepository.cs
+++ b/apps/monolith/src/ContosoUniversity.Application/Contracts/Repositories/Reads/IDepartmentsRoRepository.cs
@@ -1,4 +1,4 @@
-namespace ContosoUniversity.Application.Contracts.Repositories.ReadOnly;
+namespace ContosoUniversity.Application.Contracts.Repositories.Reads;
 
 using System;
 using System.Collections.Generic;

--- a/apps/monolith/src/ContosoUniversity.Application/Contracts/Repositories/Reads/IInstructorsRoRepository.cs
+++ b/apps/monolith/src/ContosoUniversity.Application/Contracts/Repositories/Reads/IInstructorsRoRepository.cs
@@ -1,4 +1,4 @@
-namespace ContosoUniversity.Application.Contracts.Repositories.ReadOnly;
+namespace ContosoUniversity.Application.Contracts.Repositories.Reads;
 
 using System;
 using System.Collections.Generic;

--- a/apps/monolith/src/ContosoUniversity.Application/Contracts/Repositories/Reads/IRoRepository.cs
+++ b/apps/monolith/src/ContosoUniversity.Application/Contracts/Repositories/Reads/IRoRepository.cs
@@ -1,10 +1,10 @@
-namespace ContosoUniversity.Application.Contracts.Repositories.ReadOnly;
+namespace ContosoUniversity.Application.Contracts.Repositories.Reads;
 
 using System;
 using System.Threading;
 using System.Threading.Tasks;
 
-using Domain;
+using ContosoUniversity.Domain;
 
 public interface IRoRepository<TProjection> where TProjection : IIdentifiable<Guid>
 {

--- a/apps/monolith/src/ContosoUniversity.Application/Contracts/Repositories/Reads/IStudentsRoRepository.cs
+++ b/apps/monolith/src/ContosoUniversity.Application/Contracts/Repositories/Reads/IStudentsRoRepository.cs
@@ -1,4 +1,4 @@
-namespace ContosoUniversity.Application.Contracts.Repositories.ReadOnly;
+namespace ContosoUniversity.Application.Contracts.Repositories.Reads;
 
 using System;
 using System.Threading;

--- a/apps/monolith/src/ContosoUniversity.Application/Contracts/Repositories/Reads/Paging/OrderRequest.cs
+++ b/apps/monolith/src/ContosoUniversity.Application/Contracts/Repositories/Reads/Paging/OrderRequest.cs
@@ -1,0 +1,3 @@
+namespace ContosoUniversity.Application.Contracts.Repositories.Reads.Paging;
+
+public record OrderRequest(string SortOrder);

--- a/apps/monolith/src/ContosoUniversity.Application/Contracts/Repositories/Reads/Paging/PageInfo.cs
+++ b/apps/monolith/src/ContosoUniversity.Application/Contracts/Repositories/Reads/Paging/PageInfo.cs
@@ -1,4 +1,4 @@
-namespace ContosoUniversity.Application.Contracts.Repositories.ReadOnly.Paging;
+namespace ContosoUniversity.Application.Contracts.Repositories.Reads.Paging;
 
 using System;
 

--- a/apps/monolith/src/ContosoUniversity.Application/Contracts/Repositories/Reads/Paging/PageRequest.cs
+++ b/apps/monolith/src/ContosoUniversity.Application/Contracts/Repositories/Reads/Paging/PageRequest.cs
@@ -1,0 +1,3 @@
+namespace ContosoUniversity.Application.Contracts.Repositories.Reads.Paging;
+
+public record PageRequest(int PageNumber, int PageSize);

--- a/apps/monolith/src/ContosoUniversity.Application/Contracts/Repositories/Reads/Paging/PagedResult.cs
+++ b/apps/monolith/src/ContosoUniversity.Application/Contracts/Repositories/Reads/Paging/PagedResult.cs
@@ -1,0 +1,3 @@
+namespace ContosoUniversity.Application.Contracts.Repositories.Reads.Paging;
+
+public record PagedResult<TEntity>(TEntity[] Items, PageInfo Info);

--- a/apps/monolith/src/ContosoUniversity.Application/Contracts/Repositories/Reads/Paging/SearchRequest.cs
+++ b/apps/monolith/src/ContosoUniversity.Application/Contracts/Repositories/Reads/Paging/SearchRequest.cs
@@ -1,0 +1,3 @@
+namespace ContosoUniversity.Application.Contracts.Repositories.Reads.Paging;
+
+public record SearchRequest(string SearchString);

--- a/apps/monolith/src/ContosoUniversity.Application/Contracts/Repositories/Reads/Projections/Course.cs
+++ b/apps/monolith/src/ContosoUniversity.Application/Contracts/Repositories/Reads/Projections/Course.cs
@@ -1,8 +1,8 @@
-namespace ContosoUniversity.Application.Contracts.Repositories.ReadOnly.Projections;
+namespace ContosoUniversity.Application.Contracts.Repositories.Reads.Projections;
 
 using System;
 
-using Domain;
+using ContosoUniversity.Domain;
 
 public record Course(
     int Code,

--- a/apps/monolith/src/ContosoUniversity.Application/Contracts/Repositories/Reads/Projections/Department.cs
+++ b/apps/monolith/src/ContosoUniversity.Application/Contracts/Repositories/Reads/Projections/Department.cs
@@ -1,8 +1,8 @@
-namespace ContosoUniversity.Application.Contracts.Repositories.ReadOnly.Projections;
+namespace ContosoUniversity.Application.Contracts.Repositories.Reads.Projections;
 
 using System;
 
-using Domain;
+using ContosoUniversity.Domain;
 
 public record Department(
     string Name,

--- a/apps/monolith/src/ContosoUniversity.Application/Contracts/Repositories/Reads/Projections/EnrollmentDateGroup.cs
+++ b/apps/monolith/src/ContosoUniversity.Application/Contracts/Repositories/Reads/Projections/EnrollmentDateGroup.cs
@@ -1,4 +1,4 @@
-namespace ContosoUniversity.Application.Contracts.Repositories.ReadOnly.Projections;
+namespace ContosoUniversity.Application.Contracts.Repositories.Reads.Projections;
 
 using System;
 

--- a/apps/monolith/src/ContosoUniversity.Application/Contracts/Repositories/Reads/Projections/Instructor.cs
+++ b/apps/monolith/src/ContosoUniversity.Application/Contracts/Repositories/Reads/Projections/Instructor.cs
@@ -1,11 +1,11 @@
-namespace ContosoUniversity.Application.Contracts.Repositories.ReadOnly.Projections;
+namespace ContosoUniversity.Application.Contracts.Repositories.Reads.Projections;
 
 using System;
 using System.Collections.Generic;
 using System.Linq;
 
-using Domain;
-using Domain.Instructor;
+using ContosoUniversity.Domain;
+using ContosoUniversity.Domain.Instructor;
 
 public record Instructor(
     string FirstName,

--- a/apps/monolith/src/ContosoUniversity.Application/Contracts/Repositories/Reads/Projections/Student.cs
+++ b/apps/monolith/src/ContosoUniversity.Application/Contracts/Repositories/Reads/Projections/Student.cs
@@ -1,10 +1,10 @@
-namespace ContosoUniversity.Application.Contracts.Repositories.ReadOnly.Projections;
+namespace ContosoUniversity.Application.Contracts.Repositories.Reads.Projections;
 
 using System;
 using System.Collections.Generic;
 
-using Domain;
-using Domain.Student;
+using ContosoUniversity.Domain;
+using ContosoUniversity.Domain.Student;
 
 public record Student(
     string LastName,

--- a/apps/monolith/src/ContosoUniversity.Application/Contracts/Repositories/Writes/ICoursesRwRepository.cs
+++ b/apps/monolith/src/ContosoUniversity.Application/Contracts/Repositories/Writes/ICoursesRwRepository.cs
@@ -1,10 +1,10 @@
-namespace ContosoUniversity.Application.Contracts.Repositories.ReadWrite;
+namespace ContosoUniversity.Application.Contracts.Repositories.Writes;
 
 using System;
 using System.Threading;
 using System.Threading.Tasks;
 
-using Domain.Course;
+using ContosoUniversity.Domain.Course;
 
 public interface ICoursesRwRepository : IRwRepository<Course>
 {

--- a/apps/monolith/src/ContosoUniversity.Application/Contracts/Repositories/Writes/IDepartmentsRwRepository.cs
+++ b/apps/monolith/src/ContosoUniversity.Application/Contracts/Repositories/Writes/IDepartmentsRwRepository.cs
@@ -1,10 +1,10 @@
-namespace ContosoUniversity.Application.Contracts.Repositories.ReadWrite;
+namespace ContosoUniversity.Application.Contracts.Repositories.Writes;
 
 using System;
 using System.Threading;
 using System.Threading.Tasks;
 
-using Domain.Department;
+using ContosoUniversity.Domain.Department;
 
 public interface IDepartmentsRwRepository : IRwRepository<Department>
 {

--- a/apps/monolith/src/ContosoUniversity.Application/Contracts/Repositories/Writes/IInstructorsRwRepository.cs
+++ b/apps/monolith/src/ContosoUniversity.Application/Contracts/Repositories/Writes/IInstructorsRwRepository.cs
@@ -1,10 +1,10 @@
-namespace ContosoUniversity.Application.Contracts.Repositories.ReadWrite;
+namespace ContosoUniversity.Application.Contracts.Repositories.Writes;
 
 using System;
 using System.Threading;
 using System.Threading.Tasks;
 
-using Domain.Instructor;
+using ContosoUniversity.Domain.Instructor;
 
 public interface IInstructorsRwRepository : IRwRepository<Instructor>
 {

--- a/apps/monolith/src/ContosoUniversity.Application/Contracts/Repositories/Writes/IRwRepository.cs
+++ b/apps/monolith/src/ContosoUniversity.Application/Contracts/Repositories/Writes/IRwRepository.cs
@@ -1,10 +1,10 @@
-namespace ContosoUniversity.Application.Contracts.Repositories.ReadWrite;
+namespace ContosoUniversity.Application.Contracts.Repositories.Writes;
 
 using System;
 using System.Threading;
 using System.Threading.Tasks;
 
-using Domain;
+using ContosoUniversity.Domain;
 
 public interface IRwRepository<TEntity> where TEntity : IIdentifiable<Guid>
 {

--- a/apps/monolith/src/ContosoUniversity.Application/Contracts/Repositories/Writes/IStudentsRwRepository.cs
+++ b/apps/monolith/src/ContosoUniversity.Application/Contracts/Repositories/Writes/IStudentsRwRepository.cs
@@ -1,10 +1,10 @@
-namespace ContosoUniversity.Application.Contracts.Repositories.ReadWrite;
+namespace ContosoUniversity.Application.Contracts.Repositories.Writes;
 
 using System;
 using System.Threading;
 using System.Threading.Tasks;
 
-using Domain.Student;
+using ContosoUniversity.Domain.Student;
 
 public interface IStudentsRwRepository : IRwRepository<Student>
 {

--- a/apps/monolith/src/ContosoUniversity.Application/Services/Courses/Commands/CreateCourseCommand.cs
+++ b/apps/monolith/src/ContosoUniversity.Application/Services/Courses/Commands/CreateCourseCommand.cs
@@ -4,7 +4,7 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 
-using Contracts.Repositories.ReadWrite;
+using Contracts.Repositories.Writes;
 
 using Domain.Course;
 

--- a/apps/monolith/src/ContosoUniversity.Application/Services/Courses/Commands/DeleteCourseCommand.cs
+++ b/apps/monolith/src/ContosoUniversity.Application/Services/Courses/Commands/DeleteCourseCommand.cs
@@ -4,7 +4,7 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 
-using Contracts.Repositories.ReadWrite;
+using Contracts.Repositories.Writes;
 
 using MediatR;
 

--- a/apps/monolith/src/ContosoUniversity.Application/Services/Courses/Commands/EditCourseCommand.cs
+++ b/apps/monolith/src/ContosoUniversity.Application/Services/Courses/Commands/EditCourseCommand.cs
@@ -4,7 +4,7 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 
-using Contracts.Repositories.ReadWrite;
+using Contracts.Repositories.Writes;
 
 using MediatR;
 

--- a/apps/monolith/src/ContosoUniversity.Application/Services/Courses/Notifications/DepartmentDeletedNotificationHandler.cs
+++ b/apps/monolith/src/ContosoUniversity.Application/Services/Courses/Notifications/DepartmentDeletedNotificationHandler.cs
@@ -3,7 +3,7 @@ namespace ContosoUniversity.Application.Services.Courses.Notifications;
 using System.Threading;
 using System.Threading.Tasks;
 
-using Contracts.Repositories.ReadWrite;
+using Contracts.Repositories.Writes;
 
 using Departments.Notifications;
 

--- a/apps/monolith/src/ContosoUniversity.Application/Services/Courses/Queries/GetCourseDetailsQuery.cs
+++ b/apps/monolith/src/ContosoUniversity.Application/Services/Courses/Queries/GetCourseDetailsQuery.cs
@@ -4,8 +4,8 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 
-using Contracts.Repositories.ReadOnly;
-using Contracts.Repositories.ReadOnly.Projections;
+using Contracts.Repositories.Reads;
+using Contracts.Repositories.Reads.Projections;
 
 using Exceptions;
 

--- a/apps/monolith/src/ContosoUniversity.Application/Services/Courses/Queries/GetCourseEditFormQuery.cs
+++ b/apps/monolith/src/ContosoUniversity.Application/Services/Courses/Queries/GetCourseEditFormQuery.cs
@@ -5,8 +5,8 @@ using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 
-using Contracts.Repositories.ReadOnly;
-using Contracts.Repositories.ReadOnly.Projections;
+using Contracts.Repositories.Reads;
+using Contracts.Repositories.Reads.Projections;
 
 using Exceptions;
 

--- a/apps/monolith/src/ContosoUniversity.Application/Services/Courses/Queries/GetCoursesIndexQuery.cs
+++ b/apps/monolith/src/ContosoUniversity.Application/Services/Courses/Queries/GetCoursesIndexQuery.cs
@@ -5,8 +5,8 @@ using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 
-using Contracts.Repositories.ReadOnly;
-using Contracts.Repositories.ReadOnly.Projections;
+using Contracts.Repositories.Reads;
+using Contracts.Repositories.Reads.Projections;
 
 using MediatR;
 

--- a/apps/monolith/src/ContosoUniversity.Application/Services/Courses/Validators/CreateCourseCommandValidator.cs
+++ b/apps/monolith/src/ContosoUniversity.Application/Services/Courses/Validators/CreateCourseCommandValidator.cs
@@ -6,7 +6,7 @@ using System.Threading.Tasks;
 
 using Commands;
 
-using Contracts.Repositories.ReadOnly;
+using Contracts.Repositories.Reads;
 
 using FluentValidation;
 

--- a/apps/monolith/src/ContosoUniversity.Application/Services/Courses/Validators/DeleteCourseCommandValidator.cs
+++ b/apps/monolith/src/ContosoUniversity.Application/Services/Courses/Validators/DeleteCourseCommandValidator.cs
@@ -6,7 +6,7 @@ using System.Threading.Tasks;
 
 using Commands;
 
-using Contracts.Repositories.ReadOnly;
+using Contracts.Repositories.Reads;
 
 using FluentValidation;
 

--- a/apps/monolith/src/ContosoUniversity.Application/Services/Courses/Validators/EditCourseCommandValidator.cs
+++ b/apps/monolith/src/ContosoUniversity.Application/Services/Courses/Validators/EditCourseCommandValidator.cs
@@ -6,7 +6,7 @@ using System.Threading.Tasks;
 
 using Commands;
 
-using Contracts.Repositories.ReadOnly;
+using Contracts.Repositories.Reads;
 
 using FluentValidation;
 

--- a/apps/monolith/src/ContosoUniversity.Application/Services/CrossContextBoundariesValidator.cs
+++ b/apps/monolith/src/ContosoUniversity.Application/Services/CrossContextBoundariesValidator.cs
@@ -4,7 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 
-using Contracts.Repositories.ReadOnly.Projections;
+using Contracts.Repositories.Reads.Projections;
 
 using Domain;
 using Domain.Student;

--- a/apps/monolith/src/ContosoUniversity.Application/Services/CrossContextBoundariesValidator.cs
+++ b/apps/monolith/src/ContosoUniversity.Application/Services/CrossContextBoundariesValidator.cs
@@ -26,7 +26,7 @@ public static class CrossContextBoundariesValidator
 
         if (notFoundDepartments.Length != 0)
         {
-            throw new Exception(
+            throw new InvalidOperationException(
                 $"Unbound contexts inconsistency. Departments not found: {notFoundDepartments.ToDisplayString()}.");
         }
     }
@@ -44,7 +44,7 @@ public static class CrossContextBoundariesValidator
 
         if (notFoundCourses.Length != 0)
         {
-            throw new Exception(
+            throw new InvalidOperationException(
                 $"Unbound contexts inconsistency. Course not found: {notFoundCourses.ToDisplayString()}.");
         }
     }
@@ -62,7 +62,7 @@ public static class CrossContextBoundariesValidator
 
         if (notFoundCourses.Length != 0)
         {
-            throw new Exception(
+            throw new InvalidOperationException(
                 $"Unbound contexts inconsistency. Course not found: {notFoundCourses.ToDisplayString()}.");
         }
     }

--- a/apps/monolith/src/ContosoUniversity.Application/Services/Departments/Commands/CreateDepartmentCommand.cs
+++ b/apps/monolith/src/ContosoUniversity.Application/Services/Departments/Commands/CreateDepartmentCommand.cs
@@ -4,7 +4,7 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 
-using Contracts.Repositories.ReadWrite;
+using Contracts.Repositories.Writes;
 
 using Domain.Department;
 

--- a/apps/monolith/src/ContosoUniversity.Application/Services/Departments/Commands/DeleteDepartmentCommand.cs
+++ b/apps/monolith/src/ContosoUniversity.Application/Services/Departments/Commands/DeleteDepartmentCommand.cs
@@ -5,8 +5,8 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
-using Contracts.Repositories.ReadOnly;
-using Contracts.Repositories.ReadWrite;
+using Contracts.Repositories.Reads;
+using Contracts.Repositories.Writes;
 
 using MediatR;
 

--- a/apps/monolith/src/ContosoUniversity.Application/Services/Departments/Commands/EditDepartmentCommand.cs
+++ b/apps/monolith/src/ContosoUniversity.Application/Services/Departments/Commands/EditDepartmentCommand.cs
@@ -4,7 +4,7 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 
-using Contracts.Repositories.ReadWrite;
+using Contracts.Repositories.Writes;
 
 using Domain.Department;
 

--- a/apps/monolith/src/ContosoUniversity.Application/Services/Departments/Notifications/CourseDeletedNotificationHandler.cs
+++ b/apps/monolith/src/ContosoUniversity.Application/Services/Departments/Notifications/CourseDeletedNotificationHandler.cs
@@ -4,7 +4,7 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 
-using Contracts.Repositories.ReadWrite;
+using Contracts.Repositories.Writes;
 
 using Courses.Notifications;
 

--- a/apps/monolith/src/ContosoUniversity.Application/Services/Departments/Queries/GetDepartmentDetailsQuery.cs
+++ b/apps/monolith/src/ContosoUniversity.Application/Services/Departments/Queries/GetDepartmentDetailsQuery.cs
@@ -4,8 +4,8 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 
-using Contracts.Repositories.ReadOnly;
-using Contracts.Repositories.ReadOnly.Projections;
+using Contracts.Repositories.Reads;
+using Contracts.Repositories.Reads.Projections;
 
 using Exceptions;
 

--- a/apps/monolith/src/ContosoUniversity.Application/Services/Departments/Queries/GetDepartmentEditFormQuery.cs
+++ b/apps/monolith/src/ContosoUniversity.Application/Services/Departments/Queries/GetDepartmentEditFormQuery.cs
@@ -5,8 +5,8 @@ using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 
-using Contracts.Repositories.ReadOnly;
-using Contracts.Repositories.ReadOnly.Projections;
+using Contracts.Repositories.Reads;
+using Contracts.Repositories.Reads.Projections;
 
 using Exceptions;
 

--- a/apps/monolith/src/ContosoUniversity.Application/Services/Departments/Queries/GetDepartmentsIndexQuery.cs
+++ b/apps/monolith/src/ContosoUniversity.Application/Services/Departments/Queries/GetDepartmentsIndexQuery.cs
@@ -4,8 +4,8 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 
-using Contracts.Repositories.ReadOnly;
-using Contracts.Repositories.ReadOnly.Projections;
+using Contracts.Repositories.Reads;
+using Contracts.Repositories.Reads.Projections;
 
 using MediatR;
 

--- a/apps/monolith/src/ContosoUniversity.Application/Services/Departments/Validators/CreateDepartmentCommandValidator.cs
+++ b/apps/monolith/src/ContosoUniversity.Application/Services/Departments/Validators/CreateDepartmentCommandValidator.cs
@@ -6,7 +6,7 @@ using System.Threading.Tasks;
 
 using Commands;
 
-using Contracts.Repositories.ReadOnly;
+using Contracts.Repositories.Reads;
 
 using FluentValidation;
 

--- a/apps/monolith/src/ContosoUniversity.Application/Services/Departments/Validators/DeleteDepartmentCommandValidator.cs
+++ b/apps/monolith/src/ContosoUniversity.Application/Services/Departments/Validators/DeleteDepartmentCommandValidator.cs
@@ -6,7 +6,7 @@ using System.Threading.Tasks;
 
 using Commands;
 
-using Contracts.Repositories.ReadOnly;
+using Contracts.Repositories.Reads;
 
 using Courses.Validators;
 

--- a/apps/monolith/src/ContosoUniversity.Application/Services/Departments/Validators/EditDepartmentCommandValidator.cs
+++ b/apps/monolith/src/ContosoUniversity.Application/Services/Departments/Validators/EditDepartmentCommandValidator.cs
@@ -6,7 +6,7 @@ using System.Threading.Tasks;
 
 using Commands;
 
-using Contracts.Repositories.ReadOnly;
+using Contracts.Repositories.Reads;
 
 using Courses.Validators;
 

--- a/apps/monolith/src/ContosoUniversity.Application/Services/Instructors/Commands/CreateInstructorCommand.cs
+++ b/apps/monolith/src/ContosoUniversity.Application/Services/Instructors/Commands/CreateInstructorCommand.cs
@@ -4,7 +4,7 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 
-using Contracts.Repositories.ReadWrite;
+using Contracts.Repositories.Writes;
 
 using Domain.Instructor;
 

--- a/apps/monolith/src/ContosoUniversity.Application/Services/Instructors/Commands/DeleteInstructorCommand.cs
+++ b/apps/monolith/src/ContosoUniversity.Application/Services/Instructors/Commands/DeleteInstructorCommand.cs
@@ -4,7 +4,7 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 
-using Contracts.Repositories.ReadWrite;
+using Contracts.Repositories.Writes;
 
 using Domain.Department;
 

--- a/apps/monolith/src/ContosoUniversity.Application/Services/Instructors/Commands/EditInstructorCommand.cs
+++ b/apps/monolith/src/ContosoUniversity.Application/Services/Instructors/Commands/EditInstructorCommand.cs
@@ -4,7 +4,7 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 
-using Contracts.Repositories.ReadWrite;
+using Contracts.Repositories.Writes;
 
 using Domain.Instructor;
 

--- a/apps/monolith/src/ContosoUniversity.Application/Services/Instructors/Notifications/DepartmentDeletedNotificationHandler.cs
+++ b/apps/monolith/src/ContosoUniversity.Application/Services/Instructors/Notifications/DepartmentDeletedNotificationHandler.cs
@@ -4,7 +4,7 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 
-using Contracts.Repositories.ReadWrite;
+using Contracts.Repositories.Writes;
 
 using Departments.Notifications;
 

--- a/apps/monolith/src/ContosoUniversity.Application/Services/Instructors/Queries/GetInstructorDetailsQuery.cs
+++ b/apps/monolith/src/ContosoUniversity.Application/Services/Instructors/Queries/GetInstructorDetailsQuery.cs
@@ -4,8 +4,8 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 
-using Contracts.Repositories.ReadOnly;
-using Contracts.Repositories.ReadOnly.Projections;
+using Contracts.Repositories.Reads;
+using Contracts.Repositories.Reads.Projections;
 
 using Exceptions;
 

--- a/apps/monolith/src/ContosoUniversity.Application/Services/Instructors/Queries/GetInstructorEditFormQuery.cs
+++ b/apps/monolith/src/ContosoUniversity.Application/Services/Instructors/Queries/GetInstructorEditFormQuery.cs
@@ -4,8 +4,8 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 
-using Contracts.Repositories.ReadOnly;
-using Contracts.Repositories.ReadOnly.Projections;
+using Contracts.Repositories.Reads;
+using Contracts.Repositories.Reads.Projections;
 
 using Exceptions;
 

--- a/apps/monolith/src/ContosoUniversity.Application/Services/Instructors/Validators/EditInstructorCommandValidator.cs
+++ b/apps/monolith/src/ContosoUniversity.Application/Services/Instructors/Validators/EditInstructorCommandValidator.cs
@@ -6,7 +6,7 @@ using System.Threading.Tasks;
 
 using Commands;
 
-using Contracts.Repositories.ReadOnly;
+using Contracts.Repositories.Reads;
 
 using Courses.Validators;
 

--- a/apps/monolith/src/ContosoUniversity.Application/Services/Students/Commands/CreateStudentCommand.cs
+++ b/apps/monolith/src/ContosoUniversity.Application/Services/Students/Commands/CreateStudentCommand.cs
@@ -4,7 +4,7 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 
-using Contracts.Repositories.ReadWrite;
+using Contracts.Repositories.Writes;
 
 using Domain.Student;
 

--- a/apps/monolith/src/ContosoUniversity.Application/Services/Students/Commands/DeleteStudentCommand.cs
+++ b/apps/monolith/src/ContosoUniversity.Application/Services/Students/Commands/DeleteStudentCommand.cs
@@ -4,7 +4,7 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 
-using Contracts.Repositories.ReadWrite;
+using Contracts.Repositories.Writes;
 
 using MediatR;
 

--- a/apps/monolith/src/ContosoUniversity.Application/Services/Students/Commands/EditStudentCommand.cs
+++ b/apps/monolith/src/ContosoUniversity.Application/Services/Students/Commands/EditStudentCommand.cs
@@ -5,7 +5,7 @@ using System.ComponentModel.DataAnnotations;
 using System.Threading;
 using System.Threading.Tasks;
 
-using Contracts.Repositories.ReadWrite;
+using Contracts.Repositories.Writes;
 
 using Domain.Student;
 

--- a/apps/monolith/src/ContosoUniversity.Application/Services/Students/Notifications/CourseDeletedNotificationHandler.cs
+++ b/apps/monolith/src/ContosoUniversity.Application/Services/Students/Notifications/CourseDeletedNotificationHandler.cs
@@ -4,7 +4,7 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 
-using Contracts.Repositories.ReadWrite;
+using Contracts.Repositories.Writes;
 
 using Courses.Notifications;
 

--- a/apps/monolith/src/ContosoUniversity.Application/Services/Students/Notifications/DepartmentDeletedNotificationHandler.cs
+++ b/apps/monolith/src/ContosoUniversity.Application/Services/Students/Notifications/DepartmentDeletedNotificationHandler.cs
@@ -5,7 +5,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
-using Contracts.Repositories.ReadWrite;
+using Contracts.Repositories.Writes;
 
 using Departments.Notifications;
 

--- a/apps/monolith/src/ContosoUniversity.Application/Services/Students/Queries/GetStudentDetailsQuery.cs
+++ b/apps/monolith/src/ContosoUniversity.Application/Services/Students/Queries/GetStudentDetailsQuery.cs
@@ -6,8 +6,8 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
-using Contracts.Repositories.ReadOnly;
-using Contracts.Repositories.ReadOnly.Projections;
+using Contracts.Repositories.Reads;
+using Contracts.Repositories.Reads.Projections;
 
 using Exceptions;
 

--- a/apps/monolith/src/ContosoUniversity.Application/Services/Students/Queries/GetStudentProjectionQuery.cs
+++ b/apps/monolith/src/ContosoUniversity.Application/Services/Students/Queries/GetStudentProjectionQuery.cs
@@ -4,8 +4,8 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 
-using Contracts.Repositories.ReadOnly;
-using Contracts.Repositories.ReadOnly.Projections;
+using Contracts.Repositories.Reads;
+using Contracts.Repositories.Reads.Projections;
 
 using Exceptions;
 

--- a/apps/monolith/src/ContosoUniversity.Application/Services/Students/Queries/GetStudentsIndexQuery.cs
+++ b/apps/monolith/src/ContosoUniversity.Application/Services/Students/Queries/GetStudentsIndexQuery.cs
@@ -4,9 +4,9 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 
-using Contracts.Repositories.ReadOnly;
-using Contracts.Repositories.ReadOnly.Paging;
-using Contracts.Repositories.ReadOnly.Projections;
+using Contracts.Repositories.Reads;
+using Contracts.Repositories.Reads.Paging;
+using Contracts.Repositories.Reads.Projections;
 
 using MediatR;
 

--- a/apps/monolith/src/ContosoUniversity.Application/Services/Students/Validators/DeleteInstructorCommandValidator.cs
+++ b/apps/monolith/src/ContosoUniversity.Application/Services/Students/Validators/DeleteInstructorCommandValidator.cs
@@ -4,7 +4,7 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 
-using Contracts.Repositories.ReadOnly;
+using Contracts.Repositories.Reads;
 
 using Courses.Validators;
 

--- a/apps/monolith/src/ContosoUniversity.Application/Services/Students/Validators/DeleteStudentCommandValidator.cs
+++ b/apps/monolith/src/ContosoUniversity.Application/Services/Students/Validators/DeleteStudentCommandValidator.cs
@@ -6,7 +6,7 @@ using System.Threading.Tasks;
 
 using Commands;
 
-using Contracts.Repositories.ReadOnly;
+using Contracts.Repositories.Reads;
 
 using Courses.Validators;
 

--- a/apps/monolith/src/ContosoUniversity.Application/Services/Students/Validators/EditStudentCommandValidator.cs
+++ b/apps/monolith/src/ContosoUniversity.Application/Services/Students/Validators/EditStudentCommandValidator.cs
@@ -6,7 +6,7 @@ using System.Threading.Tasks;
 
 using Commands;
 
-using Contracts.Repositories.ReadOnly;
+using Contracts.Repositories.Reads;
 
 using Courses.Validators;
 

--- a/apps/monolith/src/ContosoUniversity.Data.Courses.Reads/EntityTypeConfigurations.cs
+++ b/apps/monolith/src/ContosoUniversity.Data.Courses.Reads/EntityTypeConfigurations.cs
@@ -1,6 +1,6 @@
 namespace ContosoUniversity.Data.Courses.Reads;
 
-using Application.Contracts.Repositories.ReadOnly.Projections;
+using Application.Contracts.Repositories.Reads.Projections;
 
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;

--- a/apps/monolith/src/ContosoUniversity.Data.Courses.Reads/ReadOnlyRepository.cs
+++ b/apps/monolith/src/ContosoUniversity.Data.Courses.Reads/ReadOnlyRepository.cs
@@ -6,8 +6,8 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
-using Application.Contracts.Repositories.ReadOnly;
-using Application.Contracts.Repositories.ReadOnly.Projections;
+using Application.Contracts.Repositories.Reads;
+using Application.Contracts.Repositories.Reads.Projections;
 
 using Microsoft.EntityFrameworkCore;
 

--- a/apps/monolith/src/ContosoUniversity.Data.Courses.Reads/StartupExtensions.cs
+++ b/apps/monolith/src/ContosoUniversity.Data.Courses.Reads/StartupExtensions.cs
@@ -1,6 +1,6 @@
 namespace ContosoUniversity.Data.Courses.Reads;
 
-using Application.Contracts.Repositories.ReadOnly;
+using Application.Contracts.Repositories.Reads;
 
 using Microsoft.Extensions.DependencyInjection;
 

--- a/apps/monolith/src/ContosoUniversity.Data.Courses.Writes/Migrations/.editorconfig
+++ b/apps/monolith/src/ContosoUniversity.Data.Courses.Writes/Migrations/.editorconfig
@@ -1,3 +1,4 @@
 [*.cs]
+dotnet_diagnostic.CA1707.severity = none # Identifiers should not contain underscores
 dotnet_diagnostic.CA1861.severity = none # Avoid constant arrays as arguments
 dotnet_diagnostic.CS8981.severity = none # The type name only contains lower-cased ascii characters

--- a/apps/monolith/src/ContosoUniversity.Data.Courses.Writes/ReadWriteRepository.cs
+++ b/apps/monolith/src/ContosoUniversity.Data.Courses.Writes/ReadWriteRepository.cs
@@ -5,7 +5,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
-using Application.Contracts.Repositories.ReadWrite;
+using Application.Contracts.Repositories.Writes;
 using Application.Exceptions;
 
 using Domain.Course;

--- a/apps/monolith/src/ContosoUniversity.Data.Courses.Writes/StartupExtensions.cs
+++ b/apps/monolith/src/ContosoUniversity.Data.Courses.Writes/StartupExtensions.cs
@@ -1,6 +1,6 @@
 namespace ContosoUniversity.Data.Courses.Writes;
 
-using Application.Contracts.Repositories.ReadWrite;
+using Application.Contracts.Repositories.Writes;
 
 using Microsoft.Extensions.DependencyInjection;
 

--- a/apps/monolith/src/ContosoUniversity.Data.Departments.Reads/DepartmentsReadOnlyRepository.cs
+++ b/apps/monolith/src/ContosoUniversity.Data.Departments.Reads/DepartmentsReadOnlyRepository.cs
@@ -6,8 +6,8 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
-using Application.Contracts.Repositories.ReadOnly;
-using Application.Contracts.Repositories.ReadOnly.Projections;
+using Application.Contracts.Repositories.Reads;
+using Application.Contracts.Repositories.Reads.Projections;
 
 using Microsoft.EntityFrameworkCore;
 

--- a/apps/monolith/src/ContosoUniversity.Data.Departments.Reads/EntityTypeConfigurations.cs
+++ b/apps/monolith/src/ContosoUniversity.Data.Departments.Reads/EntityTypeConfigurations.cs
@@ -2,14 +2,14 @@ namespace ContosoUniversity.Data.Departments.Reads;
 
 using System;
 
-using Application.Contracts.Repositories.ReadOnly.Projections;
+using Application.Contracts.Repositories.Reads.Projections;
 
 using Domain.Instructor;
 
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 
-using Instructor = Application.Contracts.Repositories.ReadOnly.Projections.Instructor;
+using Instructor = Application.Contracts.Repositories.Reads.Projections.Instructor;
 
 internal class EntityTypeConfigurations :
     IEntityTypeConfiguration<Instructor>,

--- a/apps/monolith/src/ContosoUniversity.Data.Departments.Reads/InstructorsReadOnlyRepository.cs
+++ b/apps/monolith/src/ContosoUniversity.Data.Departments.Reads/InstructorsReadOnlyRepository.cs
@@ -6,8 +6,8 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
-using Application.Contracts.Repositories.ReadOnly;
-using Application.Contracts.Repositories.ReadOnly.Projections;
+using Application.Contracts.Repositories.Reads;
+using Application.Contracts.Repositories.Reads.Projections;
 
 using Microsoft.EntityFrameworkCore;
 

--- a/apps/monolith/src/ContosoUniversity.Data.Departments.Reads/ReadOnlyContext.cs
+++ b/apps/monolith/src/ContosoUniversity.Data.Departments.Reads/ReadOnlyContext.cs
@@ -1,12 +1,12 @@
 namespace ContosoUniversity.Data.Departments.Reads;
 
-using Application.Contracts.Repositories.ReadOnly.Projections;
+using Application.Contracts.Repositories.Reads.Projections;
 
 using Domain.Instructor;
 
 using Microsoft.EntityFrameworkCore;
 
-using Instructor = Application.Contracts.Repositories.ReadOnly.Projections.Instructor;
+using Instructor = Application.Contracts.Repositories.Reads.Projections.Instructor;
 
 internal class ReadOnlyContext(DbContextOptions<ReadOnlyContext> options) : DbContext(options)
 {

--- a/apps/monolith/src/ContosoUniversity.Data.Departments.Reads/StartupExtensions.cs
+++ b/apps/monolith/src/ContosoUniversity.Data.Departments.Reads/StartupExtensions.cs
@@ -1,6 +1,6 @@
 namespace ContosoUniversity.Data.Departments.Reads;
 
-using Application.Contracts.Repositories.ReadOnly;
+using Application.Contracts.Repositories.Reads;
 
 using Microsoft.Extensions.DependencyInjection;
 

--- a/apps/monolith/src/ContosoUniversity.Data.Departments.Writes/DepartmentsReadWriteRepository.cs
+++ b/apps/monolith/src/ContosoUniversity.Data.Departments.Writes/DepartmentsReadWriteRepository.cs
@@ -5,7 +5,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
-using Application.Contracts.Repositories.ReadWrite;
+using Application.Contracts.Repositories.Writes;
 
 using Domain.Department;
 

--- a/apps/monolith/src/ContosoUniversity.Data.Departments.Writes/InstructorsReadWriteRepository.cs
+++ b/apps/monolith/src/ContosoUniversity.Data.Departments.Writes/InstructorsReadWriteRepository.cs
@@ -5,7 +5,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
-using Application.Contracts.Repositories.ReadWrite;
+using Application.Contracts.Repositories.Writes;
 
 using Domain.Instructor;
 

--- a/apps/monolith/src/ContosoUniversity.Data.Departments.Writes/Migrations/.editorconfig
+++ b/apps/monolith/src/ContosoUniversity.Data.Departments.Writes/Migrations/.editorconfig
@@ -1,3 +1,4 @@
 [*.cs]
+dotnet_diagnostic.CA1707.severity = none # Identifiers should not contain underscores
 dotnet_diagnostic.CA1861.severity = none # Avoid constant arrays as arguments
 dotnet_diagnostic.CS8981.severity = none # The type name only contains lower-cased ascii characters

--- a/apps/monolith/src/ContosoUniversity.Data.Departments.Writes/StartupExtensions.cs
+++ b/apps/monolith/src/ContosoUniversity.Data.Departments.Writes/StartupExtensions.cs
@@ -1,6 +1,6 @@
 namespace ContosoUniversity.Data.Departments.Writes;
 
-using Application.Contracts.Repositories.ReadWrite;
+using Application.Contracts.Repositories.Writes;
 
 using Microsoft.Extensions.DependencyInjection;
 

--- a/apps/monolith/src/ContosoUniversity.Data.Students.Reads/EntityTypeConfigurations.cs
+++ b/apps/monolith/src/ContosoUniversity.Data.Students.Reads/EntityTypeConfigurations.cs
@@ -5,7 +5,7 @@ using Domain.Student;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 
-using Student = Application.Contracts.Repositories.ReadOnly.Projections.Student;
+using Student = Application.Contracts.Repositories.Reads.Projections.Student;
 
 internal class EntityTypeConfigurations :
     IEntityTypeConfiguration<Enrollment>,

--- a/apps/monolith/src/ContosoUniversity.Data.Students.Reads/ReadOnlyContext.cs
+++ b/apps/monolith/src/ContosoUniversity.Data.Students.Reads/ReadOnlyContext.cs
@@ -4,7 +4,7 @@ using Domain.Student;
 
 using Microsoft.EntityFrameworkCore;
 
-using Student = Application.Contracts.Repositories.ReadOnly.Projections.Student;
+using Student = Application.Contracts.Repositories.Reads.Projections.Student;
 
 internal class ReadOnlyContext(DbContextOptions<ReadOnlyContext> options) : DbContext(options)
 {

--- a/apps/monolith/src/ContosoUniversity.Data.Students.Reads/ReadOnlyRepository.cs
+++ b/apps/monolith/src/ContosoUniversity.Data.Students.Reads/ReadOnlyRepository.cs
@@ -7,9 +7,9 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
-using Application.Contracts.Repositories.ReadOnly;
-using Application.Contracts.Repositories.ReadOnly.Paging;
-using Application.Contracts.Repositories.ReadOnly.Projections;
+using Application.Contracts.Repositories.Reads;
+using Application.Contracts.Repositories.Reads.Paging;
+using Application.Contracts.Repositories.Reads.Projections;
 
 using Microsoft.EntityFrameworkCore;
 

--- a/apps/monolith/src/ContosoUniversity.Data.Students.Reads/StartupExtensions.cs
+++ b/apps/monolith/src/ContosoUniversity.Data.Students.Reads/StartupExtensions.cs
@@ -1,6 +1,6 @@
 namespace ContosoUniversity.Data.Students.Reads;
 
-using Application.Contracts.Repositories.ReadOnly;
+using Application.Contracts.Repositories.Reads;
 
 using Microsoft.Extensions.DependencyInjection;
 

--- a/apps/monolith/src/ContosoUniversity.Data.Students.Writes/Migrations/.editorconfig
+++ b/apps/monolith/src/ContosoUniversity.Data.Students.Writes/Migrations/.editorconfig
@@ -1,3 +1,4 @@
 [*.cs]
+dotnet_diagnostic.CA1707.severity = none # Identifiers should not contain underscores
 dotnet_diagnostic.CA1861.severity = none # Avoid constant arrays as arguments
 dotnet_diagnostic.CS8981.severity = none # The type name only contains lower-cased ascii characters

--- a/apps/monolith/src/ContosoUniversity.Data.Students.Writes/ReadWriteRepository.cs
+++ b/apps/monolith/src/ContosoUniversity.Data.Students.Writes/ReadWriteRepository.cs
@@ -5,7 +5,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
-using Application.Contracts.Repositories.ReadWrite;
+using Application.Contracts.Repositories.Writes;
 
 using Domain.Student;
 

--- a/apps/monolith/src/ContosoUniversity.Data.Students.Writes/StartupExtensions.cs
+++ b/apps/monolith/src/ContosoUniversity.Data.Students.Writes/StartupExtensions.cs
@@ -1,6 +1,6 @@
 namespace ContosoUniversity.Data.Students.Writes;
 
-using Application.Contracts.Repositories.ReadWrite;
+using Application.Contracts.Repositories.Writes;
 
 using Microsoft.Extensions.DependencyInjection;
 

--- a/apps/monolith/src/ContosoUniversity.Data/EfRoRepository.cs
+++ b/apps/monolith/src/ContosoUniversity.Data/EfRoRepository.cs
@@ -5,7 +5,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
-using Application.Contracts.Repositories.ReadOnly;
+using Application.Contracts.Repositories.Reads;
 
 using Domain;
 

--- a/apps/monolith/src/ContosoUniversity.Data/EfRoRepository.cs
+++ b/apps/monolith/src/ContosoUniversity.Data/EfRoRepository.cs
@@ -14,9 +14,9 @@ using Microsoft.EntityFrameworkCore;
 public abstract class EfRoRepository<TProjection> : IRoRepository<TProjection>
     where TProjection : class, IIdentifiable<Guid>
 {
-    protected DbContext DbContext { get; set; }
-    protected IQueryable<TProjection> DbQuery { get; set; }
-    protected DbSet<TProjection> DbSet { get; set; }
+    protected DbContext DbContext { get; }
+    protected IQueryable<TProjection> DbQuery { get; }
+    protected DbSet<TProjection> DbSet { get; }
 
     protected EfRoRepository(DbContext dbContext)
     {

--- a/apps/monolith/src/ContosoUniversity.Data/EfRoRepository.cs
+++ b/apps/monolith/src/ContosoUniversity.Data/EfRoRepository.cs
@@ -14,9 +14,9 @@ using Microsoft.EntityFrameworkCore;
 public abstract class EfRoRepository<TProjection> : IRoRepository<TProjection>
     where TProjection : class, IIdentifiable<Guid>
 {
-    protected readonly DbContext DbContext;
-    protected readonly IQueryable<TProjection> DbQuery;
-    protected readonly DbSet<TProjection> DbSet;
+    protected DbContext DbContext { get; set; }
+    protected IQueryable<TProjection> DbQuery { get; set; }
+    protected DbSet<TProjection> DbSet { get; set; }
 
     protected EfRoRepository(DbContext dbContext)
     {

--- a/apps/monolith/src/ContosoUniversity.Data/EfRwRepository.cs
+++ b/apps/monolith/src/ContosoUniversity.Data/EfRwRepository.cs
@@ -14,9 +14,9 @@ using Microsoft.EntityFrameworkCore;
 public abstract class EfRwRepository<TDomainEntity> : IRwRepository<TDomainEntity>
     where TDomainEntity : class, IIdentifiable<Guid>
 {
-    protected readonly DbContext DbContext;
-    protected readonly IQueryable<TDomainEntity> DbQuery;
-    protected readonly DbSet<TDomainEntity> DbSet;
+    protected DbContext DbContext { get; set; }
+    protected IQueryable<TDomainEntity> DbQuery { get; set; }
+    protected DbSet<TDomainEntity> DbSet { get; set; }
 
     protected EfRwRepository(DbContext dbContext)
     {

--- a/apps/monolith/src/ContosoUniversity.Data/EfRwRepository.cs
+++ b/apps/monolith/src/ContosoUniversity.Data/EfRwRepository.cs
@@ -14,9 +14,9 @@ using Microsoft.EntityFrameworkCore;
 public abstract class EfRwRepository<TDomainEntity> : IRwRepository<TDomainEntity>
     where TDomainEntity : class, IIdentifiable<Guid>
 {
-    protected DbContext DbContext { get; set; }
-    protected IQueryable<TDomainEntity> DbQuery { get; set; }
-    protected DbSet<TDomainEntity> DbSet { get; set; }
+    protected DbContext DbContext { get; }
+    protected IQueryable<TDomainEntity> DbQuery { get; }
+    protected DbSet<TDomainEntity> DbSet { get; }
 
     protected EfRwRepository(DbContext dbContext)
     {

--- a/apps/monolith/src/ContosoUniversity.Data/EfRwRepository.cs
+++ b/apps/monolith/src/ContosoUniversity.Data/EfRwRepository.cs
@@ -5,7 +5,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
-using Application.Contracts.Repositories.ReadWrite;
+using Application.Contracts.Repositories.Writes;
 
 using Domain;
 

--- a/apps/monolith/src/ContosoUniversity.Data/PagingExtensions.cs
+++ b/apps/monolith/src/ContosoUniversity.Data/PagingExtensions.cs
@@ -4,7 +4,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
-using Application.Contracts.Repositories.ReadOnly.Paging;
+using Application.Contracts.Repositories.Reads.Paging;
 
 using Microsoft.EntityFrameworkCore;
 

--- a/apps/monolith/src/ContosoUniversity.Mvc/Controllers/CoursesController.cs
+++ b/apps/monolith/src/ContosoUniversity.Mvc/Controllers/CoursesController.cs
@@ -6,9 +6,9 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
-using Application.Contracts.Repositories.ReadOnly;
-using Application.Contracts.Repositories.ReadOnly.Projections;
-using Application.Contracts.Repositories.ReadWrite;
+using Application.Contracts.Repositories.Reads;
+using Application.Contracts.Repositories.Reads.Projections;
+using Application.Contracts.Repositories.Writes;
 using Application.Services.Courses.Commands;
 using Application.Services.Courses.Queries;
 

--- a/apps/monolith/src/ContosoUniversity.Mvc/Controllers/DepartmentsController.cs
+++ b/apps/monolith/src/ContosoUniversity.Mvc/Controllers/DepartmentsController.cs
@@ -6,8 +6,8 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
-using Application.Contracts.Repositories.ReadOnly;
-using Application.Contracts.Repositories.ReadOnly.Projections;
+using Application.Contracts.Repositories.Reads;
+using Application.Contracts.Repositories.Reads.Projections;
 using Application.Services.Departments.Commands;
 using Application.Services.Departments.Queries;
 

--- a/apps/monolith/src/ContosoUniversity.Mvc/Controllers/HomeController.cs
+++ b/apps/monolith/src/ContosoUniversity.Mvc/Controllers/HomeController.cs
@@ -5,8 +5,8 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
-using Application.Contracts.Repositories.ReadOnly;
-using Application.Contracts.Repositories.ReadOnly.Projections;
+using Application.Contracts.Repositories.Reads;
+using Application.Contracts.Repositories.Reads.Projections;
 
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;

--- a/apps/monolith/src/ContosoUniversity.Mvc/Controllers/InstructorsController.cs
+++ b/apps/monolith/src/ContosoUniversity.Mvc/Controllers/InstructorsController.cs
@@ -6,8 +6,8 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
-using Application.Contracts.Repositories.ReadOnly;
-using Application.Contracts.Repositories.ReadOnly.Projections;
+using Application.Contracts.Repositories.Reads;
+using Application.Contracts.Repositories.Reads.Projections;
 using Application.Services;
 using Application.Services.Instructors.Commands;
 using Application.Services.Instructors.Queries;

--- a/apps/monolith/src/ContosoUniversity.Mvc/Controllers/StudentsController.cs
+++ b/apps/monolith/src/ContosoUniversity.Mvc/Controllers/StudentsController.cs
@@ -5,8 +5,8 @@ using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 
-using Application.Contracts.Repositories.ReadOnly.Paging;
-using Application.Contracts.Repositories.ReadOnly.Projections;
+using Application.Contracts.Repositories.Reads.Paging;
+using Application.Contracts.Repositories.Reads.Projections;
 using Application.Services.Students.Commands;
 using Application.Services.Students.Queries;
 

--- a/apps/monolith/src/ContosoUniversity.Mvc/ViewModels/Courses/CourseDetailsViewModel.cs
+++ b/apps/monolith/src/ContosoUniversity.Mvc/ViewModels/Courses/CourseDetailsViewModel.cs
@@ -3,7 +3,7 @@ namespace ContosoUniversity.Mvc.ViewModels.Courses;
 using System;
 using System.ComponentModel.DataAnnotations;
 
-using Application.Contracts.Repositories.ReadOnly.Projections;
+using Application.Contracts.Repositories.Reads.Projections;
 
 public class CourseDetailsViewModel
 {

--- a/apps/monolith/src/ContosoUniversity.Mvc/ViewModels/Courses/EditCourseRequest.cs
+++ b/apps/monolith/src/ContosoUniversity.Mvc/ViewModels/Courses/EditCourseRequest.cs
@@ -2,7 +2,7 @@ namespace ContosoUniversity.Mvc.ViewModels.Courses;
 
 using System;
 
-using Application.Contracts.Repositories.ReadOnly.Projections;
+using Application.Contracts.Repositories.Reads.Projections;
 
 public record EditCourseRequest
 {

--- a/apps/monolith/src/ContosoUniversity.Mvc/ViewModels/Departments/DepartmentDetailsViewModel.cs
+++ b/apps/monolith/src/ContosoUniversity.Mvc/ViewModels/Departments/DepartmentDetailsViewModel.cs
@@ -3,7 +3,7 @@ namespace ContosoUniversity.Mvc.ViewModels.Departments;
 using System;
 using System.ComponentModel.DataAnnotations;
 
-using Application.Contracts.Repositories.ReadOnly.Projections;
+using Application.Contracts.Repositories.Reads.Projections;
 
 public class DepartmentDetailsViewModel
 {

--- a/apps/monolith/src/ContosoUniversity.Mvc/ViewModels/Departments/DepartmentListItemViewModel.cs
+++ b/apps/monolith/src/ContosoUniversity.Mvc/ViewModels/Departments/DepartmentListItemViewModel.cs
@@ -3,7 +3,7 @@ namespace ContosoUniversity.Mvc.ViewModels.Departments;
 using System;
 using System.ComponentModel.DataAnnotations;
 
-using Application.Contracts.Repositories.ReadOnly.Projections;
+using Application.Contracts.Repositories.Reads.Projections;
 
 public class DepartmentListItemViewModel
 {

--- a/apps/monolith/src/ContosoUniversity.Mvc/ViewModels/Departments/EditDepartmentRequest.cs
+++ b/apps/monolith/src/ContosoUniversity.Mvc/ViewModels/Departments/EditDepartmentRequest.cs
@@ -2,7 +2,7 @@ namespace ContosoUniversity.Mvc.ViewModels.Departments;
 
 using System;
 
-using Application.Contracts.Repositories.ReadOnly.Projections;
+using Application.Contracts.Repositories.Reads.Projections;
 
 public record EditDepartmentRequest
 {

--- a/apps/monolith/src/ContosoUniversity.Mvc/ViewModels/DomainExtensions.cs
+++ b/apps/monolith/src/ContosoUniversity.Mvc/ViewModels/DomainExtensions.cs
@@ -4,7 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 
-using Application.Contracts.Repositories.ReadOnly.Projections;
+using Application.Contracts.Repositories.Reads.Projections;
 
 using Domain.Student;
 

--- a/apps/monolith/src/ContosoUniversity.Mvc/ViewModels/Instructors/CreateInstructorForm.cs
+++ b/apps/monolith/src/ContosoUniversity.Mvc/ViewModels/Instructors/CreateInstructorForm.cs
@@ -2,7 +2,7 @@ namespace ContosoUniversity.Mvc.ViewModels.Instructors;
 
 using System.ComponentModel.DataAnnotations;
 
-using Application.Contracts.Repositories.ReadOnly.Projections;
+using Application.Contracts.Repositories.Reads.Projections;
 
 public record CreateInstructorForm(Course[] Courses)
 {

--- a/apps/monolith/src/ContosoUniversity.Mvc/ViewModels/Instructors/EditInstructorForm.cs
+++ b/apps/monolith/src/ContosoUniversity.Mvc/ViewModels/Instructors/EditInstructorForm.cs
@@ -2,7 +2,7 @@ namespace ContosoUniversity.Mvc.ViewModels.Instructors;
 
 using System.ComponentModel.DataAnnotations;
 
-using Application.Contracts.Repositories.ReadOnly.Projections;
+using Application.Contracts.Repositories.Reads.Projections;
 
 public record EditInstructorForm(Instructor Instructor, Course[] Courses)
 {

--- a/apps/monolith/src/ContosoUniversity.Mvc/ViewModels/Instructors/EditInstructorRequest.cs
+++ b/apps/monolith/src/ContosoUniversity.Mvc/ViewModels/Instructors/EditInstructorRequest.cs
@@ -2,7 +2,7 @@ namespace ContosoUniversity.Mvc.ViewModels.Instructors;
 
 using System;
 
-using Application.Contracts.Repositories.ReadOnly.Projections;
+using Application.Contracts.Repositories.Reads.Projections;
 
 public record EditInstructorRequest
 {

--- a/apps/monolith/src/ContosoUniversity.Mvc/ViewModels/Instructors/InstructorDetailsViewModel.cs
+++ b/apps/monolith/src/ContosoUniversity.Mvc/ViewModels/Instructors/InstructorDetailsViewModel.cs
@@ -3,7 +3,7 @@ namespace ContosoUniversity.Mvc.ViewModels.Instructors;
 using System;
 using System.ComponentModel.DataAnnotations;
 
-using Application.Contracts.Repositories.ReadOnly.Projections;
+using Application.Contracts.Repositories.Reads.Projections;
 
 public class InstructorDetailsViewModel
 {

--- a/apps/monolith/src/ContosoUniversity.Mvc/ViewModels/Students/EditStudentRequest.cs
+++ b/apps/monolith/src/ContosoUniversity.Mvc/ViewModels/Students/EditStudentRequest.cs
@@ -3,7 +3,7 @@ namespace ContosoUniversity.Mvc.ViewModels.Students;
 using System;
 using System.ComponentModel.DataAnnotations;
 
-using Application.Contracts.Repositories.ReadOnly.Projections;
+using Application.Contracts.Repositories.Reads.Projections;
 
 public record EditStudentRequest
 {

--- a/apps/monolith/src/ContosoUniversity.Mvc/ViewModels/Students/StudentDeletePageViewModel.cs
+++ b/apps/monolith/src/ContosoUniversity.Mvc/ViewModels/Students/StudentDeletePageViewModel.cs
@@ -3,7 +3,7 @@ namespace ContosoUniversity.Mvc.ViewModels.Students;
 using System;
 using System.ComponentModel.DataAnnotations;
 
-using Application.Contracts.Repositories.ReadOnly.Projections;
+using Application.Contracts.Repositories.Reads.Projections;
 
 public class StudentDeletePageViewModel
 {

--- a/apps/monolith/src/ContosoUniversity.Mvc/ViewModels/Students/StudentDetailsViewModel.cs
+++ b/apps/monolith/src/ContosoUniversity.Mvc/ViewModels/Students/StudentDetailsViewModel.cs
@@ -5,7 +5,7 @@ using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.Linq;
 
-using Application.Contracts.Repositories.ReadOnly.Projections;
+using Application.Contracts.Repositories.Reads.Projections;
 
 public class StudentDetailsViewModel
 {

--- a/apps/monolith/src/ContosoUniversity.Mvc/ViewModels/Students/StudentIndexViewModel.cs
+++ b/apps/monolith/src/ContosoUniversity.Mvc/ViewModels/Students/StudentIndexViewModel.cs
@@ -3,8 +3,8 @@ namespace ContosoUniversity.Mvc.ViewModels.Students;
 using System;
 using System.Linq;
 
-using Application.Contracts.Repositories.ReadOnly.Paging;
-using Application.Contracts.Repositories.ReadOnly.Projections;
+using Application.Contracts.Repositories.Reads.Paging;
+using Application.Contracts.Repositories.Reads.Projections;
 using Application.Services.Students.Queries;
 
 public class StudentIndexViewModel

--- a/apps/monolith/test/integration/ContosoUniversity.Mvc.IntegrationTests/ContosoUniversity.Mvc.IntegrationTests.csproj
+++ b/apps/monolith/test/integration/ContosoUniversity.Mvc.IntegrationTests/ContosoUniversity.Mvc.IntegrationTests.csproj
@@ -1,5 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
+    <PropertyGroup>
+        <NoWarn>$(NoWarn);CA1707</NoWarn>
+    </PropertyGroup>
+
     <ItemGroup>
         <PackageReference Include="FluentAssertions" />
         <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" />

--- a/apps/monolith/test/integration/ContosoUniversity.Mvc.IntegrationTests/DefaultApplicationFactory.cs
+++ b/apps/monolith/test/integration/ContosoUniversity.Mvc.IntegrationTests/DefaultApplicationFactory.cs
@@ -14,7 +14,7 @@ using Microsoft.Extensions.DependencyInjection.Extensions;
 
 public class DefaultApplicationFactory : WebApplicationFactory<IAssemblyMarker>
 {
-    public Func<string> DataSourceSetterFunction = () => string.Empty;
+    public Func<string> DataSourceSetterFunction { get; set; } = () => string.Empty;
 
     protected override void ConfigureWebHost(IWebHostBuilder builder)
     {

--- a/apps/monolith/test/system/ContosoUniversity.SystemTests/ContosoUniversity.SystemTests.csproj
+++ b/apps/monolith/test/system/ContosoUniversity.SystemTests/ContosoUniversity.SystemTests.csproj
@@ -1,5 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
+    <PropertyGroup>
+        <NoWarn>$(NoWarn);CA1707</NoWarn>
+    </PropertyGroup>
+
     <ItemGroup>
         <PackageReference Include="Ductus.FluentDocker" />
         <PackageReference Include="FluentAssertions" />

--- a/apps/monolith/test/system/ContosoUniversity.SystemTests/SutUrls.cs
+++ b/apps/monolith/test/system/ContosoUniversity.SystemTests/SutUrls.cs
@@ -4,7 +4,7 @@ using Microsoft.Extensions.Configuration;
 
 public class SutUrls(IConfiguration configuration)
 {
-    public readonly string BaseAddress = $"{configuration["PageBaseUrl:Http"]}";
+    public string BaseAddress => $"{configuration["PageBaseUrl:Http"]}";
     public string CoursesCreatePage => $"{BaseAddress}/Courses/Create";
     public string CoursesDeletePage => $"{BaseAddress}/Courses/Delete";
     public string CoursesEditPage => $"{BaseAddress}/Courses/Edit";

--- a/apps/monolith/test/system/ContosoUniversity.SystemTests/SutUrls.cs
+++ b/apps/monolith/test/system/ContosoUniversity.SystemTests/SutUrls.cs
@@ -4,7 +4,7 @@ using Microsoft.Extensions.Configuration;
 
 public class SutUrls(IConfiguration configuration)
 {
-    public string BaseAddress => $"{configuration["PageBaseUrl:Http"]}";
+    public string BaseAddress { get; } = configuration["PageBaseUrl:Http"] ?? string.Empty;
     public string CoursesCreatePage => $"{BaseAddress}/Courses/Create";
     public string CoursesDeletePage => $"{BaseAddress}/Courses/Delete";
     public string CoursesEditPage => $"{BaseAddress}/Courses/Edit";

--- a/apps/mservices/.editorconfig
+++ b/apps/mservices/.editorconfig
@@ -74,7 +74,6 @@ dotnet_diagnostic.CS1591.severity = none # Missing XML comment for publicly visi
 
 # AnalysisMode: Recommended
 dotnet_diagnostic.CA1305.severity = none # Specify IFormatProvider
-dotnet_diagnostic.CA1707.severity = none # Identifiers should not contain underscores
 dotnet_diagnostic.CA1711.severity = none # Identifiers should not have incorrect suffix
 dotnet_diagnostic.CA1848.severity = none # Use the LoggerMessage delegates
 dotnet_diagnostic.CA1852.severity = none # Seal internal types

--- a/apps/mservices/.editorconfig
+++ b/apps/mservices/.editorconfig
@@ -75,7 +75,6 @@ dotnet_diagnostic.CS1591.severity = none # Missing XML comment for publicly visi
 # AnalysisMode: Recommended
 dotnet_diagnostic.CA1305.severity = none # Specify IFormatProvider
 dotnet_diagnostic.CA1711.severity = none # Identifiers should not have incorrect suffix
-dotnet_diagnostic.CA1848.severity = none # Use the LoggerMessage delegates
 dotnet_diagnostic.CA1852.severity = none # Seal internal types
 
 # AnalysisMode: All

--- a/apps/mservices/.editorconfig
+++ b/apps/mservices/.editorconfig
@@ -73,7 +73,6 @@ dotnet_diagnostic.IDE0290.severity = error # Use primary constructor
 dotnet_diagnostic.CS1591.severity = none # Missing XML comment for publicly visible type or member
 
 # AnalysisMode: Recommended
-dotnet_diagnostic.CA1051.severity = none # Do not declare visible instance fields
 dotnet_diagnostic.CA1305.severity = none # Specify IFormatProvider
 dotnet_diagnostic.CA1707.severity = none # Identifiers should not contain underscores
 dotnet_diagnostic.CA1711.severity = none # Identifiers should not have incorrect suffix

--- a/apps/mservices/.editorconfig
+++ b/apps/mservices/.editorconfig
@@ -69,12 +69,12 @@ dotnet_diagnostic.IDE0051.severity = error # Remove unused private members
 dotnet_diagnostic.IDE0052.severity = error # Remove unread private member
 dotnet_diagnostic.IDE0290.severity = error # Use primary constructor
 
-# Global suppressions
+# Global compiler suppressions
 dotnet_diagnostic.CS1591.severity = none # Missing XML comment for publicly visible type or member
 
-# AnalysisMode: Recommended
-dotnet_diagnostic.CA1305.severity = none # Specify IFormatProvider
-dotnet_diagnostic.CA1852.severity = none # Seal internal types
+# Global analyser suppressions
+dotnet_diagnostic.CA1305.severity = none # Recommended - Specify IFormatProvider
+dotnet_diagnostic.CA1852.severity = none # Recommended - Seal internal types
 
 # AnalysisMode: All
 dotnet_diagnostic.CA1002.severity = none # Do not expose generic lists

--- a/apps/mservices/.editorconfig
+++ b/apps/mservices/.editorconfig
@@ -74,7 +74,6 @@ dotnet_diagnostic.CS1591.severity = none # Missing XML comment for publicly visi
 
 # AnalysisMode: Recommended
 dotnet_diagnostic.CA1305.severity = none # Specify IFormatProvider
-dotnet_diagnostic.CA1711.severity = none # Identifiers should not have incorrect suffix
 dotnet_diagnostic.CA1852.severity = none # Seal internal types
 
 # AnalysisMode: All

--- a/apps/mservices/.editorconfig
+++ b/apps/mservices/.editorconfig
@@ -79,7 +79,6 @@ dotnet_diagnostic.CA1707.severity = none # Identifiers should not contain unders
 dotnet_diagnostic.CA1711.severity = none # Identifiers should not have incorrect suffix
 dotnet_diagnostic.CA1848.severity = none # Use the LoggerMessage delegates
 dotnet_diagnostic.CA1852.severity = none # Seal internal types
-dotnet_diagnostic.CA2201.severity = none # Do not raise reserved exception types
 
 # AnalysisMode: All
 dotnet_diagnostic.CA1002.severity = none # Do not expose generic lists

--- a/apps/mservices/src/ContosoUniversity.Application/CrossContextBoundariesValidator.cs
+++ b/apps/mservices/src/ContosoUniversity.Application/CrossContextBoundariesValidator.cs
@@ -23,7 +23,7 @@ public static class CrossContextBoundariesValidator
 
         if (notFoundDepartments.Length != 0)
         {
-            throw new Exception(
+            throw new InvalidOperationException(
                 $"Unbound contexts inconsistency. Departments not found: {notFoundDepartments.ToDisplayString()}.");
         }
     }
@@ -41,7 +41,7 @@ public static class CrossContextBoundariesValidator
 
         if (notFoundCourses.Length != 0)
         {
-            throw new Exception(
+            throw new InvalidOperationException(
                 $"Unbound contexts inconsistency. Course not found: {notFoundCourses.ToDisplayString()}.");
         }
     }
@@ -59,7 +59,7 @@ public static class CrossContextBoundariesValidator
 
         if (notFoundCourses.Length != 0)
         {
-            throw new Exception(
+            throw new InvalidOperationException(
                 $"Unbound contexts inconsistency. Course not found: {notFoundCourses.ToDisplayString()}.");
         }
     }

--- a/apps/mservices/src/ContosoUniversity.Data/EfRoRepository.cs
+++ b/apps/mservices/src/ContosoUniversity.Data/EfRoRepository.cs
@@ -12,9 +12,9 @@ using SharedKernel;
 public abstract class EfRoRepository<TProjection> : IRoRepository<TProjection>
     where TProjection : class, IIdentifiable<Guid>
 {
-    protected readonly DbContext DbContext;
-    protected readonly IQueryable<TProjection> DbQuery;
-    protected readonly DbSet<TProjection> DbSet;
+    protected DbContext DbContext { get; set; }
+    protected IQueryable<TProjection> DbQuery { get; set; }
+    protected DbSet<TProjection> DbSet { get; set; }
 
     protected EfRoRepository(DbContext dbContext)
     {

--- a/apps/mservices/src/ContosoUniversity.Data/EfRoRepository.cs
+++ b/apps/mservices/src/ContosoUniversity.Data/EfRoRepository.cs
@@ -12,9 +12,9 @@ using SharedKernel;
 public abstract class EfRoRepository<TProjection> : IRoRepository<TProjection>
     where TProjection : class, IIdentifiable<Guid>
 {
-    protected DbContext DbContext { get; set; }
-    protected IQueryable<TProjection> DbQuery { get; set; }
-    protected DbSet<TProjection> DbSet { get; set; }
+    protected DbContext DbContext { get; }
+    protected IQueryable<TProjection> DbQuery { get; }
+    protected DbSet<TProjection> DbSet { get; }
 
     protected EfRoRepository(DbContext dbContext)
     {

--- a/apps/mservices/src/ContosoUniversity.Data/EfRwRepository.cs
+++ b/apps/mservices/src/ContosoUniversity.Data/EfRwRepository.cs
@@ -12,9 +12,9 @@ using SharedKernel;
 public abstract class EfRwRepository<TDomainEntity> : IRwRepository<TDomainEntity>
     where TDomainEntity : class, IIdentifiable<Guid>
 {
-    protected DbContext DbContext { get; set; }
-    protected IQueryable<TDomainEntity> DbQuery { get; set; }
-    protected DbSet<TDomainEntity> DbSet { get; set; }
+    protected DbContext DbContext { get; }
+    protected IQueryable<TDomainEntity> DbQuery { get; }
+    protected DbSet<TDomainEntity> DbSet { get; }
 
     protected EfRwRepository(DbContext dbContext)
     {

--- a/apps/mservices/src/ContosoUniversity.Data/EfRwRepository.cs
+++ b/apps/mservices/src/ContosoUniversity.Data/EfRwRepository.cs
@@ -12,9 +12,9 @@ using SharedKernel;
 public abstract class EfRwRepository<TDomainEntity> : IRwRepository<TDomainEntity>
     where TDomainEntity : class, IIdentifiable<Guid>
 {
-    protected readonly DbContext DbContext;
-    protected readonly IQueryable<TDomainEntity> DbQuery;
-    protected readonly DbSet<TDomainEntity> DbSet;
+    protected DbContext DbContext { get; set; }
+    protected IQueryable<TDomainEntity> DbQuery { get; set; }
+    protected DbSet<TDomainEntity> DbSet { get; set; }
 
     protected EfRwRepository(DbContext dbContext)
     {

--- a/apps/mservices/src/Courses.Data.Writes/Migrations/.editorconfig
+++ b/apps/mservices/src/Courses.Data.Writes/Migrations/.editorconfig
@@ -1,3 +1,4 @@
 [*.cs]
+dotnet_diagnostic.CA1707.severity = none # Identifiers should not contain underscores
 dotnet_diagnostic.CA1861.severity = none # Avoid constant arrays as arguments
 dotnet_diagnostic.CS8981.severity = none # The type name only contains lower-cased ascii characters

--- a/apps/mservices/src/Departments.Data.Writes/Migrations/.editorconfig
+++ b/apps/mservices/src/Departments.Data.Writes/Migrations/.editorconfig
@@ -1,3 +1,4 @@
 [*.cs]
+dotnet_diagnostic.CA1707.severity = none # Identifiers should not contain underscores
 dotnet_diagnostic.CA1861.severity = none # Avoid constant arrays as arguments
 dotnet_diagnostic.CS8981.severity = none # The type name only contains lower-cased ascii characters

--- a/apps/mservices/src/Students.Data.Writes/Migrations/.editorconfig
+++ b/apps/mservices/src/Students.Data.Writes/Migrations/.editorconfig
@@ -1,3 +1,4 @@
 [*.cs]
+dotnet_diagnostic.CA1707.severity = none # Identifiers should not contain underscores
 dotnet_diagnostic.CA1861.severity = none # Avoid constant arrays as arguments
 dotnet_diagnostic.CS8981.severity = none # The type name only contains lower-cased ascii characters

--- a/apps/mservices/test/integration/ContosoUniversity.Mvc.IntegrationTests/ContosoUniversity.Mvc.IntegrationTests.csproj
+++ b/apps/mservices/test/integration/ContosoUniversity.Mvc.IntegrationTests/ContosoUniversity.Mvc.IntegrationTests.csproj
@@ -1,5 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
+    <PropertyGroup>
+        <NoWarn>$(NoWarn);CA1707</NoWarn>
+    </PropertyGroup>
+
     <ItemGroup>
         <PackageReference Include="FluentAssertions" />
         <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" />

--- a/apps/mservices/test/integration/ContosoUniversity.Mvc.IntegrationTests/HeaderNavigationTests.cs
+++ b/apps/mservices/test/integration/ContosoUniversity.Mvc.IntegrationTests/HeaderNavigationTests.cs
@@ -10,7 +10,7 @@ using Microsoft.AspNetCore.Mvc.Testing;
 
 using Xunit;
 
-[Collection(nameof(SharedTestCollection))]
+[Collection(nameof(SharedTestFixture))]
 public class HeaderNavigationTests :
     IClassFixture<TestsConfiguration>,
     IClassFixture<WebApplicationFactory<IAssemblyMarker>>

--- a/apps/mservices/test/integration/ContosoUniversity.Mvc.IntegrationTests/SharedTestCollection.cs
+++ b/apps/mservices/test/integration/ContosoUniversity.Mvc.IntegrationTests/SharedTestCollection.cs
@@ -1,6 +1,0 @@
-namespace ContosoUniversity.Mvc.IntegrationTests;
-
-using Xunit;
-
-[CollectionDefinition(nameof(SharedTestCollection))]
-public class SharedTestCollection : ICollectionFixture<SharedTestContext>;

--- a/apps/mservices/test/integration/ContosoUniversity.Mvc.IntegrationTests/SharedTestFixture.cs
+++ b/apps/mservices/test/integration/ContosoUniversity.Mvc.IntegrationTests/SharedTestFixture.cs
@@ -1,0 +1,6 @@
+namespace ContosoUniversity.Mvc.IntegrationTests;
+
+using Xunit;
+
+[CollectionDefinition(nameof(SharedTestFixture))]
+public class SharedTestFixture : ICollectionFixture<SharedTestContext>;

--- a/apps/mservices/test/integration/Courses.Api.IntegrationTests/Courses.Api.IntegrationTests.csproj
+++ b/apps/mservices/test/integration/Courses.Api.IntegrationTests/Courses.Api.IntegrationTests.csproj
@@ -1,6 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
+        <NoWarn>$(NoWarn);CA1707</NoWarn>
+    </PropertyGroup>
+
+    <PropertyGroup>
         <ImplicitUsings>enable</ImplicitUsings>
         <IsTestProject>true</IsTestProject>
     </PropertyGroup>

--- a/apps/mservices/test/integration/Courses.Worker.IntegrationTests/Courses.Worker.IntegrationTests.csproj
+++ b/apps/mservices/test/integration/Courses.Worker.IntegrationTests/Courses.Worker.IntegrationTests.csproj
@@ -1,6 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
+        <NoWarn>$(NoWarn);CA1707</NoWarn>
+    </PropertyGroup>
+
+    <PropertyGroup>
         <ImplicitUsings>enable</ImplicitUsings>
         <IsTestProject>true</IsTestProject>
     </PropertyGroup>

--- a/apps/mservices/test/integration/Departments.Api.IntegrationTests/Departments.Api.IntegrationTests.csproj
+++ b/apps/mservices/test/integration/Departments.Api.IntegrationTests/Departments.Api.IntegrationTests.csproj
@@ -1,6 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
+        <NoWarn>$(NoWarn);CA1707</NoWarn>
+    </PropertyGroup>
+
+    <PropertyGroup>
         <ImplicitUsings>enable</ImplicitUsings>
         <IsTestProject>true</IsTestProject>
     </PropertyGroup>

--- a/apps/mservices/test/integration/Departments.Worker.IntegrationTests/Departments.Worker.IntegrationTests.csproj
+++ b/apps/mservices/test/integration/Departments.Worker.IntegrationTests/Departments.Worker.IntegrationTests.csproj
@@ -1,6 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
+        <NoWarn>$(NoWarn);CA1707</NoWarn>
+    </PropertyGroup>
+
+    <PropertyGroup>
         <ImplicitUsings>enable</ImplicitUsings>
         <IsTestProject>true</IsTestProject>
     </PropertyGroup>

--- a/apps/mservices/test/integration/IntegrationTesting.SharedKernel/DefaultApplicationFactory.cs
+++ b/apps/mservices/test/integration/IntegrationTesting.SharedKernel/DefaultApplicationFactory.cs
@@ -12,8 +12,8 @@ using Microsoft.Extensions.DependencyInjection;
 public class DefaultApplicationFactory<TAssemblyMarker>
     : WebApplicationFactory<TAssemblyMarker> where TAssemblyMarker : class
 {
-    public Func<string> DataSourceSetterFunction = () => string.Empty;
-    public Func<string> RabbitMqConnectionSetterFunction;
+    public Func<string> DataSourceSetterFunction { get; set; } = () => string.Empty;
+    public Func<string> RabbitMqConnectionSetterFunction { get; set; }
 
     protected override void ConfigureWebHost(IWebHostBuilder builder)
     {

--- a/apps/mservices/test/integration/Students.Api.IntegrationTests/Students.Api.IntegrationTests.csproj
+++ b/apps/mservices/test/integration/Students.Api.IntegrationTests/Students.Api.IntegrationTests.csproj
@@ -1,6 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
+        <NoWarn>$(NoWarn);CA1707</NoWarn>
+    </PropertyGroup>
+
+    <PropertyGroup>
         <ImplicitUsings>enable</ImplicitUsings>
         <IsTestProject>true</IsTestProject>
     </PropertyGroup>

--- a/apps/mservices/test/integration/Students.Worker.IntegrationTests/Students.Worker.IntegrationTests.csproj
+++ b/apps/mservices/test/integration/Students.Worker.IntegrationTests/Students.Worker.IntegrationTests.csproj
@@ -1,6 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
+        <NoWarn>$(NoWarn);CA1707</NoWarn>
+    </PropertyGroup>
+
+    <PropertyGroup>
         <ImplicitUsings>enable</ImplicitUsings>
         <IsTestProject>true</IsTestProject>
     </PropertyGroup>

--- a/apps/mservices/test/system/ContosoUniversity.SystemTests/ContosoUniversity.SystemTests.csproj
+++ b/apps/mservices/test/system/ContosoUniversity.SystemTests/ContosoUniversity.SystemTests.csproj
@@ -1,5 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
+    <PropertyGroup>
+        <NoWarn>$(NoWarn);CA1707</NoWarn>
+    </PropertyGroup>
+
     <ItemGroup>
         <PackageReference Include="Ductus.FluentDocker" />
         <PackageReference Include="FluentAssertions" />

--- a/apps/mservices/test/system/ContosoUniversity.SystemTests/SutUrls.cs
+++ b/apps/mservices/test/system/ContosoUniversity.SystemTests/SutUrls.cs
@@ -4,7 +4,7 @@ using Microsoft.Extensions.Configuration;
 
 public class SutUrls(IConfiguration configuration)
 {
-    public readonly string BaseAddress = $"{configuration["PageBaseUrl:Http"]}";
+    public string BaseAddress => $"{configuration["PageBaseUrl:Http"]}";
     public string CoursesCreatePage => $"{BaseAddress}/Courses/Create";
     public string CoursesDeletePage => $"{BaseAddress}/Courses/Delete";
     public string CoursesEditPage => $"{BaseAddress}/Courses/Edit";

--- a/apps/mservices/test/system/ContosoUniversity.SystemTests/SutUrls.cs
+++ b/apps/mservices/test/system/ContosoUniversity.SystemTests/SutUrls.cs
@@ -4,7 +4,7 @@ using Microsoft.Extensions.Configuration;
 
 public class SutUrls(IConfiguration configuration)
 {
-    public string BaseAddress => $"{configuration["PageBaseUrl:Http"]}";
+    public string BaseAddress { get; } = configuration["PageBaseUrl:Http"] ?? string.Empty;
     public string CoursesCreatePage => $"{BaseAddress}/Courses/Create";
     public string CoursesDeletePage => $"{BaseAddress}/Courses/Delete";
     public string CoursesEditPage => $"{BaseAddress}/Courses/Edit";


### PR DESCRIPTION
Fixed violations for most of the `AnalysisMode=Recommended` suppressions.
A couple of suppressions were accepted for future fix/decision:
- #233: **Specify IFormatProvider**
- #248: **Seal internal types**

---
This pull request restructures the repository contract namespaces in the application layer to use more consistent and descriptive naming. Specifically, it replaces the previous `ReadOnly` and `ReadWrite` namespaces with `Reads` and `Writes`, and updates all related file paths, type imports, and namespace declarations accordingly. Additionally, there are minor improvements to `.editorconfig` for analyzer suppressions.

### Namespace and Directory Refactoring

**Read-only repository contracts:**
* All interfaces and related types under `ContosoUniversity.Application.Contracts.Repositories.ReadOnly` have been renamed and moved to `ContosoUniversity.Application.Contracts.Repositories.Reads`. This includes files like `ICoursesRoRepository`, `IDepartmentsRoRepository`, `IInstructorsRoRepository`, `IStudentsRoRepository`, `IRoRepository`, and all types under `ReadOnly/Paging` and `ReadOnly/Projections` directories. Namespace declarations and relevant using statements have been updated to match. [[1]](diffhunk://#diff-7ed8eabd218221623ee8b95d66a9b565fa0ea5447f457d6b53d28388ea646e83L1-R1) [[2]](diffhunk://#diff-f0b426bab01e6608da61bcce01e5d4cbc54523f7b23bf58482f3797565d947efL1-R1) [[3]](diffhunk://#diff-9f92cc29e1e2146c3ca4100219099a37bb1edc054c1929f9352202b6d4d9f1b4L1-R1) [[4]](diffhunk://#diff-987ec7ea41ddd11153c6f20443b2f02bca09a1ce29c65fce981965b9e495ddd9L1-R1) [[5]](diffhunk://#diff-59dc5744fda1661b703fa4679f4d54b2e33b1c3036f886053fa5c24f9e900de0L1-R1) [[6]](diffhunk://#diff-4222fc9a72579f786deb877991578436b81893361f657a390294931eb5b63c59L1-R1) [[7]](diffhunk://#diff-a3b477db44f31513e12c9f2d68fcee097bbcdfb4f1bb82502c10178332de2e84L1-R1) [[8]](diffhunk://#diff-00272c8ecb78a5913caeaf3f661e52b1e9fdedcf7307e0e09ea8d2727281aaf3L1-R1) [[9]](diffhunk://#diff-59f69b46df9a55117e718aca8d15416426c3ae2fe7ca101ed354967fd0d0ae02L1-R1) [[10]](diffhunk://#diff-bd3654439fc18442d19abbf8e67052c6e0cd7bb7f5fb096f14dffa95a041183dL1-R5) [[11]](diffhunk://#diff-51e6e0551715745296757fc57cbeac94400cbddd59b12fac1324e0f17485ba68L1-R5) [[12]](diffhunk://#diff-7d8cb8b6c16f651ee29ec52ee311549236b3368b61fab3311d42ae3129ec19dbL1-R1) [[13]](diffhunk://#diff-db537e289356a74e27e6dd8f175c80b871b08630460dba920cedc95055362c8bL1-R8) [[14]](diffhunk://#diff-2469a59f57845d86c541cdc78bb8495364c99d24676dfc66bcf6a2bf01a95776L1-R7) [[15]](diffhunk://#diff-96de8d78d3100260c6dccaa0b4b6225ca8e671d069fab1c21bdd3ecf2b847a73L1-R7)

**Read-write repository contracts:**
* All interfaces previously under `ContosoUniversity.Application.Contracts.Repositories.ReadWrite` have been renamed and moved to `ContosoUniversity.Application.Contracts.Repositories.Writes`, with corresponding updates to namespace declarations and type imports. This affects files such as `ICoursesRwRepository`, `IDepartmentsRwRepository`, `IInstructorsRwRepository`, and `IRwRepository`. [[1]](diffhunk://#diff-57b1a3805a07715de7a98db20e0f237b07fea9c67d060ac01d01a5e559d2eeb2L1-R7) [[2]](diffhunk://#diff-53923eac28bf1db0e9dfd0667bca5df1ffa50719707c7c2ee5a2a52368b54deeL1-R7) [[3]](diffhunk://#diff-8399d4609a959669bc8f84d0d453f8479e3d24fbbbf5d1d9e7e66750a7ef670cL1-R7) [[4]](diffhunk://#diff-237632f135bea3dd2863476c52788e5641068766af3bde1ee41750e4c42b034bL1-R7)

### Code Quality and Analyzer Configuration

* The `.editorconfig` file is updated to clarify and reorganize global analyzer suppressions, distinguishing between "compiler suppressions" and "analyser suppressions", and removing or consolidating some redundant suppression lines.

These changes improve codebase consistency, make repository contract intentions clearer, and help maintain a more organized project structure.