### PR TITLE
CONTOSO: Add nuget source configuration (#253)

### DIFF
--- a/apps/mservices/Directory.Packages.props
+++ b/apps/mservices/Directory.Packages.props
@@ -46,7 +46,7 @@
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.9" />
     <PackageVersion Include="Testcontainers.MsSql" Version="4.12.0" />
     <PackageVersion Include="Testcontainers.RabbitMq" Version="4.12.0" />
-    <PackageVersion Include="WireMock.Net" Version="2.11.0" />
+    <PackageVersion Include="WireMock.Net" Version="2.12.0" />
     <PackageVersion Include="xunit" Version="2.9.3" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>

--- a/nuget.config
+++ b/nuget.config
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
+  </packageSources>
+</configuration>


### PR DESCRIPTION
This pull request introduces a new `nuget.config` file to specify the NuGet package source and updates the `WireMock.Net` package version in the solution. These changes help standardize package management and ensure compatibility with the latest features and fixes.

Dependency management improvements:

* Added a new `nuget.config` file to explicitly set the NuGet package source to `nuget.org`, ensuring consistent package resolution across environments.
* Updated the `WireMock.Net` package version from `2.11.0` to `2.12.0` in `Directory.Packages.props` to incorporate the latest updates and bug fixes.