### PR TITLE
CONTOSO: Split web image names

### DIFF
--- a/.github/workflows/deploy-mnlth-prepare-artifacts.yml
+++ b/.github/workflows/deploy-mnlth-prepare-artifacts.yml
@@ -9,8 +9,8 @@ on:
 
 jobs:
 
-  build-push-cuweb:
-    name: Build & Push cuweb
+  build-push-web-monolith:
+    name: Build & Push web-monolith
     runs-on: ubuntu-latest
 
     steps:
@@ -41,14 +41,14 @@ jobs:
         id: metadata
         uses: docker/metadata-action@v6
         with:
-          images: ghcr.io/alexbohomol/cuweb
+          images: ghcr.io/alexbohomol/web-monolith
           tags: |
             # Use short SHA from PR head or latest commit on default branch
             type=raw,value=${{ steps.extract-sha.outputs.SHORT_SHA }}
             # Set 'latest' tag for default branch
             type=raw,value=latest,enable={{is_default_branch}}
 
-      - name: Build and push cuweb image
+      - name: Build and push web-monolith image
         uses: docker/build-push-action@v7
         with:
           context: ${{ vars.MONOLITH_SLN_PATH }}

--- a/.github/workflows/deploy-mnlth-qa-aws-ecs-run.yml
+++ b/.github/workflows/deploy-mnlth-qa-aws-ecs-run.yml
@@ -143,7 +143,7 @@ jobs:
         with:
           task-definition-family: contoso-mnlth-web-tasks
           container-name: web
-          image: ghcr.io/alexbohomol/cuweb:${{ needs.get_image_tag.outputs.IMAGE_TAG }}
+          image: ghcr.io/alexbohomol/web-monolith:${{ needs.get_image_tag.outputs.IMAGE_TAG }}
 
       - name: 🚀 Kick off application instances
         uses: aws-actions/amazon-ecs-deploy-task-definition@v2

--- a/.github/workflows/deploy-mnlth-qa-aws-ecs-stop.yml
+++ b/.github/workflows/deploy-mnlth-qa-aws-ecs-stop.yml
@@ -26,7 +26,7 @@ jobs:
         with:
           task-definition-family: contoso-mnlth-web-tasks
           container-name: web
-          image: ghcr.io/alexbohomol/cuweb
+          image: ghcr.io/alexbohomol/web-monolith
 
       - name: 🛑 Stop application
         uses: aws-actions/amazon-ecs-deploy-task-definition@v2

--- a/.github/workflows/pr-mnlth-full.yml
+++ b/.github/workflows/pr-mnlth-full.yml
@@ -35,14 +35,14 @@ jobs:
         with:
           context: ${{ vars.MONOLITH_SLN_PATH }}
           file: ${{ vars.MONOLITH_SLN_PATH }}/src/ContosoUniversity.Mvc/Dockerfile
-          tags: cuweb:latest
-          outputs: type=docker,dest=${{ runner.temp }}/cuweb.tar
+          tags: web-monolith:latest
+          outputs: type=docker,dest=${{ runner.temp }}/web-monolith.tar
 
       - name: Upload artifact
         uses: actions/upload-artifact@v7
         with:
-          name: cuweb
-          path: ${{ runner.temp }}/cuweb.tar
+          name: web-monolith
+          path: ${{ runner.temp }}/web-monolith.tar
 
   check_system_health:
     name: Check System Health
@@ -59,12 +59,12 @@ jobs:
       - name: Download artifact
         uses: actions/download-artifact@v8
         with:
-          name: cuweb
+          name: web-monolith
           path: ${{ runner.temp }}
 
       - name: Load image
         run: |
-          docker load --input ${{ runner.temp }}/cuweb.tar
+          docker load --input ${{ runner.temp }}/web-monolith.tar
           docker image ls -a
 
       - name: Run Docker Compose Up
@@ -77,15 +77,15 @@ jobs:
       - name: List Docker containers
         run: docker container ls --all
 
-      - name: Inspect container | cuweb
-        run: docker inspect cuweb
+      - name: Inspect container | web-monolith
+        run: docker inspect web-monolith
 
-      - name: Curl to cuweb
+      - name: Curl to web-monolith
         run: curl http://localhost:10000/Courses
 
-      - name: Grab container logs | cuweb
+      - name: Grab container logs | web-monolith
         if: always()
-        run: docker logs cuweb
+        run: docker logs web-monolith
 
       - name: Grab container logs | mssql
         if: always()
@@ -124,12 +124,12 @@ jobs:
     - name: Download artifact
       uses: actions/download-artifact@v8
       with:
-        name: cuweb
+        name: web-monolith
         path: ${{ runner.temp }}
 
     - name: Load image
       run: |
-        docker load --input ${{ runner.temp }}/cuweb.tar
+        docker load --input ${{ runner.temp }}/web-monolith.tar
         docker image ls -a
 
     - name: Setup .NET
@@ -178,12 +178,12 @@ jobs:
     - name: Download artifact
       uses: actions/download-artifact@v8
       with:
-        name: cuweb
+        name: web-monolith
         path: ${{ runner.temp }}
 
     - name: Load image
       run: |
-        docker load --input ${{ runner.temp }}/cuweb.tar
+        docker load --input ${{ runner.temp }}/web-monolith.tar
         docker image ls -a
 
     - name: Setup .NET

--- a/.github/workflows/pr-msvc-full.yml
+++ b/.github/workflows/pr-msvc-full.yml
@@ -19,7 +19,7 @@ jobs:
       matrix:
         include:
         - title: ContosoUniversity.Mvc
-          image_name: cuweb
+          image_name: web-mservices
           proj_path: src/ContosoUniversity.Mvc
         - title: Courses.Api
           image_name: courses-api
@@ -48,7 +48,7 @@ jobs:
         uses: docker/setup-buildx-action@v4
 
       - name: Developer Cert
-        if: ${{ matrix.image_name == 'cuweb' }}
+        if: ${{ matrix.image_name == 'web-mservices' }}
         working-directory: ${{ vars.MSERVICES_SLN_PATH }}/${{ matrix.proj_path }}
         run: |
           dotnet dev-certs https -ep cert.pfx -p Test1234!
@@ -81,10 +81,10 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v6
 
-    - name: Download artifact | cuweb
+    - name: Download artifact | web-mservices
       uses: actions/download-artifact@v8
       with:
-          name: cuweb
+          name: web-mservices
           path: ${{ runner.temp }}
 
     - name: Download artifact | courses-api
@@ -125,7 +125,7 @@ jobs:
 
     - name: Load images
       run: |
-        docker load --input ${{ runner.temp }}/cuweb.tar
+        docker load --input ${{ runner.temp }}/web-mservices.tar
         docker load --input ${{ runner.temp }}/courses-api.tar
         docker load --input ${{ runner.temp }}/courses-worker.tar
         docker load --input ${{ runner.temp }}/departments-api.tar
@@ -149,11 +149,11 @@ jobs:
       if: always()
       run: docker inspect students-api
 
-    - name: Inspect container | cuweb
+    - name: Inspect container | web-mservices
       if: always()
-      run: docker inspect cuweb
+      run: docker inspect web-mservices
 
-    - name: Curl to cuweb
+    - name: Curl to web-mservices
       if: always()
       run: curl http://localhost:10000/Courses
 
@@ -181,9 +181,9 @@ jobs:
       if: always()
       run: curl http://localhost:5037/health/readiness | jq .
 
-    - name: Grab container logs | cuweb
+    - name: Grab container logs | web-mservices
       if: always()
-      run: docker logs cuweb
+      run: docker logs web-mservices
 
     - name: Grab container logs | mssql
       if: always()
@@ -242,10 +242,10 @@ jobs:
         docker-compose version
         ls -lah
 
-    - name: Download artifact | cuweb
+    - name: Download artifact | web-mservices
       uses: actions/download-artifact@v8
       with:
-        name: cuweb
+        name: web-mservices
         path: ${{ runner.temp }}
 
     - name: Download artifact | courses-api
@@ -286,7 +286,7 @@ jobs:
 
     - name: Load images
       run: |
-        docker load --input ${{ runner.temp }}/cuweb.tar
+        docker load --input ${{ runner.temp }}/web-mservices.tar
         docker load --input ${{ runner.temp }}/courses-api.tar
         docker load --input ${{ runner.temp }}/courses-worker.tar
         docker load --input ${{ runner.temp }}/departments-api.tar
@@ -337,10 +337,10 @@ jobs:
         docker-compose version
         ls -lah
 
-    - name: Download artifact | cuweb
+    - name: Download artifact | web-mservices
       uses: actions/download-artifact@v8
       with:
-        name: cuweb
+        name: web-mservices
         path: ${{ runner.temp }}
 
     - name: Download artifact | courses-api
@@ -381,7 +381,7 @@ jobs:
 
     - name: Load images
       run: |
-        docker load --input ${{ runner.temp }}/cuweb.tar
+        docker load --input ${{ runner.temp }}/web-mservices.tar
         docker load --input ${{ runner.temp }}/courses-api.tar
         docker load --input ${{ runner.temp }}/courses-worker.tar
         docker load --input ${{ runner.temp }}/departments-api.tar

--- a/apps/monolith/docker-compose.yml
+++ b/apps/monolith/docker-compose.yml
@@ -4,8 +4,8 @@ networks:
 
 services:
   web:
-    image: cuweb
-    container_name: cuweb
+    image: web-monolith
+    container_name: web-monolith
     hostname: web
     depends_on:
       mssql:

--- a/apps/monolith/iac/envs/qa-aws-ecs/main.tf
+++ b/apps/monolith/iac/envs/qa-aws-ecs/main.tf
@@ -163,7 +163,7 @@ resource "aws_ecs_task_definition" "web_task" {
     {
       essential = true
       name      = "web"
-      image     = "ghcr.io/alexbohomol/cuweb"
+      image     = "ghcr.io/alexbohomol/web-monolith"
       portMappings = [
         {
           containerPort = 80,

--- a/apps/mservices/docker-compose.yml
+++ b/apps/mservices/docker-compose.yml
@@ -4,8 +4,8 @@ networks:
 
 services:
   web:
-    image: cuweb
-    container_name: cuweb
+    image: web-mservices
+    container_name: web-mservices
     hostname: web
     depends_on:
       courses-api:


### PR DESCRIPTION
This pull request standardizes the naming of Docker images and containers for both the monolith and microservices applications across the codebase and CI/CD workflows. The main change is renaming the old `cuweb` image and container references to `web-monolith` for the monolith app and to `web-mservices` for the microservices app. This improves clarity and consistency in build, deployment, and infrastructure configurations.

**Monolith application renaming:**

* All references to the `cuweb` Docker image and container are renamed to `web-monolith` in GitHub Actions workflows, `docker-compose.yml`, and Terraform ECS task definitions.

**Microservices application renaming:**

* All references to the `cuweb` Docker image and container are renamed to `web-mservices` in GitHub Actions workflows and `docker-compose.yml`.

These changes ensure that your build, deployment, and local development environments use clear and consistent naming for the web components, reducing confusion and potential deployment errors.